### PR TITLE
Fix template variable handling in bash scripts

### DIFF
--- a/.github/actions/cde-discovery-action/action.yml
+++ b/.github/actions/cde-discovery-action/action.yml
@@ -27,6 +27,11 @@ runs:
     - name: Create CDE Discovery Prompt
       shell: bash
       run: ./.github/actions/cde-discovery-action/create-prompt.sh
+      env:
+        ISSUE_NUMBER: ${{ github.event.issue.number }}
+        ISSUE_TITLE: ${{ github.event.issue.title }}
+        ISSUE_BODY: ${{ github.event.issue.body }}
+        ISSUE_USER: ${{ github.event.issue.user.login }}
 
     - name: Run Claude Code for CDE Discovery
       uses: ./.github/actions/claude-code-action
@@ -44,4 +49,5 @@ runs:
       run: ./.github/actions/cde-discovery-action/post-results.sh
       env:
         GH_TOKEN: ${{ inputs.github_token }}
+        ISSUE_NUMBER: ${{ github.event.issue.number }}
 

--- a/.github/actions/cde-discovery-action/create-prompt.sh
+++ b/.github/actions/cde-discovery-action/create-prompt.sh
@@ -7,10 +7,10 @@ You are a CDE (Common Data Element) discovery assistant for biomedical research 
 TASK: Analyze the GitHub issue request below and find relevant CDEs from the repository's data sources.
 
 ISSUE DETAILS:
-- Issue Number: ${{ github.event.issue.number }}
-- Title: ${{ github.event.issue.title }}
-- Body: ${{ github.event.issue.body }}
-- User: ${{ github.event.issue.user.login }}
+- Issue Number: ${ISSUE_NUMBER}
+- Title: ${ISSUE_TITLE}
+- Body: ${ISSUE_BODY}
+- User: ${ISSUE_USER}
 
 REPOSITORY CONTEXT:
 - This repo contains CDEs from multiple sources: PhenX-REDCap, NIH/NLM, CADSR, RADx-UP

--- a/.github/actions/cde-discovery-action/post-results.sh
+++ b/.github/actions/cde-discovery-action/post-results.sh
@@ -2,7 +2,7 @@
 
 # Check if Claude output exists and post as comment using gh CLI
 if [ -f /tmp/claude-output.txt ]; then
-  echo "Posting Claude's CDE discovery results to issue #${{ github.event.issue.number }}"
+  echo "Posting Claude's CDE discovery results to issue #${ISSUE_NUMBER}"
   
   # Create formatted comment
   cat > /tmp/issue-comment.md << 'EOF'
@@ -17,7 +17,7 @@ EOF
   cat /tmp/claude-output.txt >> /tmp/issue-comment.md
   
   # Post comment using GitHub CLI
-  gh issue comment ${{ github.event.issue.number }} --body-file /tmp/issue-comment.md
+  gh issue comment ${ISSUE_NUMBER} --body-file /tmp/issue-comment.md
 else
   echo "Error: No Claude output found to post"
   exit 1


### PR DESCRIPTION
## Summary
Fixes the 'bad substitution' error in the cde-discovery-action bash scripts.

## Problem
The bash scripts contained GitHub Actions template variables like  which were being interpreted by bash as variable substitutions, causing errors.

## Solution
- Pass GitHub Actions template variables as environment variables to the scripts
- Update scripts to use  syntax instead of template syntax
- Add  sections to pass the required variables

## Changes
- **create-prompt.sh**: Use  etc. instead of template variables
- **post-results.sh**: Use  instead of template variables  
- **action.yml**: Add  sections to pass template variables as environment variables

## Test plan
- [x] Bash scripts now use proper environment variable syntax
- [ ] GitHub Actions should run without 'bad substitution' errors

🤖 Generated with [Claude Code](https://claude.ai/code)