### PR TITLE
Fix duplicate posting issue

### DIFF
--- a/.github/actions/cde-discovery-action/post-results.sh
+++ b/.github/actions/cde-discovery-action/post-results.sh
@@ -11,12 +11,17 @@ if [ -f /tmp/claude-output.txt ]; then
     head -5 /tmp/claude-output.txt
     
     echo "Posting Claude's CDE discovery results to issue #${ISSUE_NUMBER}"
+  echo "GitHub Actor: ${GITHUB_ACTOR}"
+  echo "GitHub Workflow: ${GITHUB_WORKFLOW}"
+  echo "GitHub Run ID: ${GITHUB_RUN_ID}"
     
-    # Create formatted comment
-    cat > /tmp/issue-comment.md << 'EOF'
+    # Create formatted comment with unique identifier
+    cat > /tmp/issue-comment.md << EOF
 # AI CDE Discovery Results
 
 Claude AI has analyzed your CDE discovery request and found the following results:
+
+*Run ID: ${GITHUB_RUN_ID} | Workflow: ${GITHUB_WORKFLOW} | Actor: ${GITHUB_ACTOR}*
 
 ---
 EOF
@@ -29,7 +34,7 @@ EOF
   else
     echo "Error: Claude output file is empty"
     echo "Creating comment about empty output..."
-    cat > /tmp/issue-comment.md << 'EOF'
+    cat > /tmp/issue-comment.md << EOF
 # AI CDE Discovery Results
 
 ⚠️ The AI analysis completed but produced no output. This might indicate:
@@ -38,6 +43,8 @@ EOF
 - The request needs to be more specific
 
 Please try rephrasing your request or adding more specific keywords.
+
+*Run ID: ${GITHUB_RUN_ID} | Workflow: ${GITHUB_WORKFLOW} | Actor: ${GITHUB_ACTOR}*
 EOF
     gh issue comment ${ISSUE_NUMBER} --body-file /tmp/issue-comment.md
   fi

--- a/.github/workflows/cde-discovery.yml
+++ b/.github/workflows/cde-discovery.yml
@@ -2,7 +2,7 @@ name: AI CDE Discovery
 
 on:
   issues:
-    types: [opened, labeled]
+    types: [labeled]
 
 jobs:
   discover-cdes:


### PR DESCRIPTION
## Summary
Fixes the issue where the CDE Discovery action was posting 3 duplicate responses.

## Root Cause
The workflow was triggering on both  and  events. When creating an issue with the  label, it would fire twice:
1. Once for the  event
2. Once for the  event

## Solution
- **Remove  trigger**: Only trigger on  events
- **Add debugging info**: Include run ID, workflow name, and actor in comments to help track duplicate sources

## Changes
- **cde-discovery.yml**: Remove  from triggers, only use 
- **post-results.sh**: Add debugging info to comments with run metadata

## Test Plan
- [x] Workflow now only triggers on label events
- [x] Added debugging to identify any remaining duplicate sources
- [ ] Test with new issue to verify single response

This should eliminate the duplicate posting while maintaining functionality when users add the  label to existing issues.

🤖 Generated with [Claude Code](https://claude.ai/code)