### PR TITLE
Remove redundant AI Analysis Tasks from CDE discovery template

### DIFF
--- a/.github/ISSUE_TEMPLATE/cde-discovery.yml
+++ b/.github/ISSUE_TEMPLATE/cde-discovery.yml
@@ -101,14 +101,3 @@ body:
       description: Are you already using any specific instruments or CDEs that new ones should be compatible with?
       placeholder: "e.g., Already using PX030604 for adult smoking, need comparable pediatric version"
 
-  - type: checkboxes
-    id: ai_tasks
-    attributes:
-      label: AI Analysis Tasks
-      description: What would you like the AI to focus on?
-      options:
-        - label: "Find exact concept matches"
-        - label: "Identify harmonization opportunities across sources"
-        - label: "Suggest population-specific alternatives (adult vs pediatric)"
-        - label: "Compare question wording and response options"
-        - label: "Recommend best practices for data collection"


### PR DESCRIPTION
## Summary
Removes the unnecessary "AI Analysis Tasks" checkbox section from the CDE discovery issue template.

## Rationale
The AI should automatically perform all these analysis tasks without requiring users to select them:
- ✅ Find exact concept matches
- ✅ Identify harmonization opportunities across sources  
- ✅ Suggest population-specific alternatives (adult vs pediatric)
- ✅ Compare question wording and response options
- ✅ Recommend best practices for data collection

## Benefits
- **Simplified UX**: Users don't need to check boxes for obvious analysis tasks
- **Cleaner template**: Removes redundant section that doesn't add value
- **Consistent behavior**: AI always performs comprehensive analysis regardless of checkboxes

## Changes
- Removed the entire `ai_tasks` checkboxes section from the template
- All analysis functionality remains in the AI prompt

The AI will continue to perform all these tasks automatically based on the research context and requirements provided.

🤖 Generated with [Claude Code](https://claude.ai/code)