### PR TITLE
Remove redundant Target Population dropdown from CDE discovery template

### DIFF
--- a/.github/ISSUE_TEMPLATE/cde-discovery.yml
+++ b/.github/ISSUE_TEMPLATE/cde-discovery.yml
@@ -45,18 +45,6 @@ body:
     validations:
       required: true
 
-  - type: dropdown
-    id: population
-    attributes:
-      label: Target Population
-      description: What population will you be studying?
-      options:
-        - Adult (18+ years)
-        - Pediatric/Adolescent (<18 years)
-        - Both adult and pediatric
-        - Not specified/population-agnostic
-    validations:
-      required: true
 
   - type: checkboxes
     id: sources

--- a/.github/actions/cde-discovery-action/create-prompt.sh
+++ b/.github/actions/cde-discovery-action/create-prompt.sh
@@ -27,7 +27,7 @@ REPOSITORY CONTEXT:
 STEPS:
 1. The GitHub issue details are provided via environment variable. Parse the user's request for:
    - Clinical concepts/variables they need
-   - Target population (adult/pediatric/both)
+   - Target population (adult/pediatric/both) - extract from research context and variable descriptions
    - Preferred data sources
    - Any specific CDE IDs mentioned
 


### PR DESCRIPTION
## Summary
Removes the "Target Population" dropdown from the CDE discovery issue template to simplify the user experience.

## Rationale
The target population information is typically already included in:
- **Research Context**: Users naturally mention age groups when describing their study ("adolescents aged 12-18", "adult patients", etc.)
- **Variables/Concepts**: Age-specific variables make the population clear ("pediatric BMI", "adult smoking cessation", etc.)

Having a separate required dropdown adds friction without providing much additional value.

## Changes
- **Template**: Removed the target population dropdown and its validation
- **AI Prompt**: Updated to extract population info from research context and variable descriptions instead of a separate field

## Benefits
- **Reduced form friction**: One less required field to fill out
- **More natural**: Users describe population in context rather than selecting from preset options
- **Maintains functionality**: AI still identifies and considers population-specific requirements
- **Cleaner UX**: Shorter, more focused template

The AI will continue to identify target populations from the contextual information provided in the research description and variable needs.

🤖 Generated with [Claude Code](https://claude.ai/code)