### PR TITLE
Set 'Any/All sources' as default in CDE discovery template

### DIFF
--- a/.github/ISSUE_TEMPLATE/cde-discovery.yml
+++ b/.github/ISSUE_TEMPLATE/cde-discovery.yml
@@ -57,6 +57,7 @@ body:
         - label: "CADSR (Cancer Data Standards Registry)"
         - label: "RADx-UP (COVID-19 research focus)"
         - label: "Any/All sources (let AI decide)"
+          required: true
 
   - type: dropdown
     id: data_format


### PR DESCRIPTION
## Summary
Makes "Any/All sources (let AI decide)" the default checked option in the CDE Sources section.

## Rationale
- **Sensible default**: Most users want comprehensive results across all available sources
- **Reduces decision fatigue**: Users don't need to understand all the different CDE sources upfront
- **Better UX**: Provides a working default while still allowing customization
- **AI-friendly**: Lets the AI determine the best sources based on the research context

## Changes
- Added `required: true` to the "Any/All sources (let AI decide)" option
- This makes it checked by default in the GitHub issue template

## Benefits
- **Faster completion**: Users can submit without having to research different CDE sources
- **Comprehensive results**: Default behavior searches all available sources
- **Still customizable**: Users can uncheck this and select specific sources if they have preferences
- **Better adoption**: Lower barrier to entry for new users

The AI will still analyze the research context to determine which sources are most relevant, but now searches all sources by default unless the user specifically constrains it.

🤖 Generated with [Claude Code](https://claude.ai/code)