### PR TITLE
Fix checkbox pre-selection to actually check 'Any/All sources' by default

### DIFF
--- a/.github/ISSUE_TEMPLATE/cde-discovery.yml
+++ b/.github/ISSUE_TEMPLATE/cde-discovery.yml
@@ -51,13 +51,12 @@ body:
     attributes:
       label: Preferred CDE Sources
       description: Which CDE sources would you prefer? (Select all that apply)
-      options:
-        - label: "PhenX Toolkit (standardized research protocols)"
-        - label: "NIH/NLM (National Library of Medicine)"
-        - label: "CADSR (Cancer Data Standards Registry)"
-        - label: "RADx-UP (COVID-19 research focus)"
-        - label: "Any/All sources (let AI decide)"
-          required: true
+      value: |
+        - [ ] PhenX Toolkit (standardized research protocols)
+        - [ ] NIH/NLM (National Library of Medicine)
+        - [ ] CADSR (Cancer Data Standards Registry)
+        - [ ] RADx-UP (COVID-19 research focus)
+        - [x] Any/All sources (let AI decide)
 
   - type: dropdown
     id: data_format


### PR DESCRIPTION
## Summary
Actually makes "Any/All sources (let AI decide)" pre-checked by default in the CDE discovery template.

## Problem
The previous attempt used `required: true` which only makes the checkbox mandatory to check, but doesn't pre-check it.

## Solution
Use the correct GitHub issue template syntax with markdown checkboxes in the `value` property:
- `[x]` for pre-checked items
- `[ ]` for unchecked items

## Changes
- Replaced `options` with `value` property using markdown checkbox syntax
- "Any/All sources (let AI decide)" is now marked with `[x]` to be pre-checked
- Other sources are marked with `[ ]` to be unchecked by default

## Result
When users open a new CDE discovery issue:
- ✅ "Any/All sources (let AI decide)" will be pre-checked
- ❌ Other specific sources will be unchecked
- Users can still modify selections as needed

This provides the actual pre-selection behavior that was requested.

🤖 Generated with [Claude Code](https://claude.ai/code)