### PR TITLE
Fix CDE discovery template syntax

### DIFF
--- a/.github/ISSUE_TEMPLATE/cde-discovery.yml
+++ b/.github/ISSUE_TEMPLATE/cde-discovery.yml
@@ -57,8 +57,6 @@ body:
         - label: "CADSR (Cancer Data Standards Registry)"
         - label: "RADx-UP (COVID-19 research focus)"
         - label: "Any/All sources (let AI decide)"
-    validations:
-      required: false
 
   - type: dropdown
     id: data_format


### PR DESCRIPTION
Simplifies the CDE sources checkbox list to basic functionality without special requirements or defaults.