### PR TITLE
Fix SSSOM mapping action to properly post to issues

### DIFF
--- a/.github/actions/sssom-mapping-action/action.yml
+++ b/.github/actions/sssom-mapping-action/action.yml
@@ -34,7 +34,8 @@ runs:
       uses: ./.github/actions/claude-code-action
       with:
         prompt_file: /tmp/claude-prompts/sssom-mapping-prompt.txt
-        allowed_tools: "Read,Write,Grep,LS,Glob"
+        allowed_tools: "mcp__github__get_issue,mcp__github__create_issue_comment,mcp__github__create_pull_request,Read,Write,Grep,LS,Glob"
+        install_artl_mcp: "true"
         timeout_minutes: ${{ inputs.timeout_minutes }}
         anthropic_api_key: ${{ inputs.anthropic_api_key }}
         cborg_api_key: ${{ inputs.cborg_api_key }}

--- a/.github/actions/sssom-mapping-action/create-prompt.sh
+++ b/.github/actions/sssom-mapping-action/create-prompt.sh
@@ -16,7 +16,7 @@ REPOSITORY CONTEXT:
   * data/radx-up/ - RADx-UP data
 
 STEPS:
-1. Parse the GitHub issue details provided via environment variables for the mapping request:
+1. Use mcp__github__get_issue to get issue details and parse the mapping request:
    - Source CDE(s) specified
    - Target CDE(s) or domain for mapping
    - Mapping scope and criteria
@@ -61,7 +61,15 @@ STEPS:
    - Harmonization recommendations
    - Potential issues or conflicts identified
 
-7. Save the SSSOM mapping file to generated-mappings/ directory and provide comprehensive analysis for manual PR creation
+7. Create a pull request with:
+   - New SSSOM mapping file in generated-mappings/
+   - Clear description of mappings and methodology
+   - Request for human review and validation
+
+8. Post a comment to the original issue with:
+   - Summary of mappings created
+   - Link to the pull request
+   - Key findings and recommendations
 
 SSSOM BEST PRACTICES:
 - Use standard mapping justification codes (lexical, logical, unspecified)


### PR DESCRIPTION
## Summary
Fixes the SSSOM mapping action so it properly posts comments to issues and creates pull requests.

## Issues Fixed

### 1. **Restored GitHub MCP Tools** ✅
- **Problem**: I incorrectly removed GitHub MCP tools that were causing WebFetch permission errors
- **Root Cause**: The issue was likely tool configuration, not the tools themselves
- **Solution**: Added back `mcp__github__get_issue`, `mcp__github__create_issue_comment`, `mcp__github__create_pull_request`

### 2. **Enable MCP Server Installation** ✅
- **Problem**: Missing `install_artl_mcp: true` parameter 
- **Solution**: Added parameter to enable GitHub MCP functionality

### 3. **Update Prompt for GitHub Integration** ✅
- **Problem**: Prompt was updated to not use GitHub MCP tools
- **Solution**: Restored prompt steps to:
  - Use `mcp__github__get_issue` to read issue details
  - Create pull request with mappings
  - Post summary comment to original issue

### 4. **Bash Command Continuation** ✅
- **Problem**: Missing backslashes in bash commands (though this was actually correct)
- **Status**: Verified bash commands are properly formed

## Expected Behavior
SSSOM mapping action should now:
1. ✅ Read GitHub issue details using MCP tools
2. ✅ Generate SSSOM mappings based on issue requirements  
3. ✅ Create pull request with mapping files
4. ✅ Post summary comment to original issue with results

## Test Plan
- [ ] Create issue with `sssom-mapping` label
- [ ] Verify action runs without WebFetch permission errors
- [ ] Confirm issue comment is posted with results
- [ ] Check that PR is created with mapping files

🤖 Generated with [Claude Code](https://claude.ai/code)