### PR TITLE
Cde2vec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,3 +72,62 @@ db/cadsr-de_flat_slim.csv:
 
 db/cadsr-de_flat_slim_primary.csv:
 	sqlite3 -header -separator $$'\t' db/cadsr.db "SELECT * FROM de_flat_slim_primary" > $@
+
+# ---------------------------------
+# Embedding with CurateGPT (Ontologies, CDEs)
+# ---------------------------------
+
+RUN =
+CURATE = curategpt
+DB_PATH = db
+
+# CurateGPT Embedding Generation for CDE schemas
+embed-nih-cde:
+	$(CURATE) view index \
+		--view linkml_schema \
+		-c cde_nih \
+		-m openai: \
+		--source-locator linkml/nih_nlm_schema.yaml \
+		-p $(DB_PATH)
+
+embed-phenx-cde:
+	$(CURATE) view index \
+		--view linkml_schema \
+		-c cde_phenx \
+		-m openai: \
+		--source-locator linkml/phenx_schema.yaml \
+		-p $(DB_PATH)
+
+embed-radx-up-cde:
+	$(CURATE) view index \
+		--view linkml_schema \
+		-c cde_radx_up \
+		-m openai: \
+		--source-locator linkml/radx_up_schema.yaml \
+		-p $(DB_PATH)
+
+# CurateGPT Embedding Generation for OBO Ontologies
+embed-hp-ontology:
+	$(CURATE) ontology index \
+		--index-fields label,definition,relationships \
+		-p $(DB_PATH) \
+		-c ont_hp \
+		-m openai: \
+		sqlite:obo:hp
+
+embed-mondo-ontology:
+	$(CURATE) ontology index \
+		--index-fields label,definition,relationships \
+		-p $(DB_PATH) \
+		-c ont_mondo \
+		-m openai: \
+		sqlite:obo:mondo
+
+embed-cl-ontology:
+	$(CURATE) ontology index \
+		--index-fields label,definition,relationships \
+		-p $(DB_PATH) \
+		-c ont_cl \
+		-m openai: \
+		sqlite:obo:cl
+>>>>>>> 7be7fdb70 (cde2vec initial)

--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,22 @@ embed-radx-up-cde:
 		--source-locator linkml/radx_up_schema.yaml \
 		-p $(DB_PATH)
 
+embed-heal-cde:
+	$(CURATE) view index \
+	   --view linkml_schema \
+	   -c cde_heal \
+	   -m openai: \
+	   --source-locator linkml/heal_schema.yaml \
+	   -p $(DB_PATH)
+
+embed-connects-cde:
+	$(CURATE) view index \
+	   --view linkml_schema \
+	   -c cde_connects \
+	   -m openai: \
+	   --source-locator linkml/connects_schema.yaml \
+	   -p $(DB_PATH)
+
 # CurateGPT Embedding Generation for OBO Ontologies
 embed-hp-ontology:
 	$(CURATE) ontology index \
@@ -130,4 +146,4 @@ embed-cl-ontology:
 		-c ont_cl \
 		-m openai: \
 		sqlite:obo:cl
->>>>>>> 7be7fdb70 (cde2vec initial)
+

--- a/cde2vec/README.md
+++ b/cde2vec/README.md
@@ -1,0 +1,88 @@
+## `cde2vec`: Embedding CDE Schemas & Ontologies
+
+The `cde2vec` component leverages [`CurateGPT`](https://github.com/monarch-initiative/curategpt) to generate semantic vector embeddings from:
+
+- **CDE schemas** in [LinkML](https://linkml.io/) format
+- **OBO ontologies** (e.g., HPO, MONDO, CL)
+
+These embeddings are stored in a local vector database for downstream tasks like semantic similarity, search, and clustering.
+
+### Prerequisites
+
+Ensure **CurateGPT** is installed. It is automatically installed via `setup.py`, but for reference, you can install it manually using:
+
+```bash
+pip install curategpt
+```
+Additionally, make sure you have your **OpenAI API key** set in your environment:
+
+```bash
+export OPENAI_API_KEY="your-api-key-here"
+```
+---
+
+# Usage
+
+Use the Makefile to index any supported ontology or schema:
+
+### 🔹 Embed CDE Schemas
+
+| Make Target           | Description                                       |
+|----------------------|-------------------------------------------------|
+| `make embed-nih-cde`    | Embed NIH/NLM CDE schema from `linkml/nih_nlm_schema.yaml`      |
+| `make embed-phenx-cde`  | Embed PhenX CDE schema from `linkml/phenx_schema.yaml`          |
+| `make embed-radx-up-cde`| Embed RADx-UP CDE schema from `linkml/radx_up_schema.yaml`      |
+
+### 🔹 Embed Ontologies
+
+| Make Target              | Description                  |
+|-------------------------|------------------------------|
+| `make embed-hp-ontology`    | Embed HPO (Human Phenotype Ontology)    |
+| `make embed-mondo-ontology` | Embed MONDO Disease Ontology             |
+| `make embed-cl-ontology`    | Embed CL (Cell Ontology)                  |
+
+---
+
+# Vector Store Location
+
+Embeddings for the following CDE Schemas and Ontologies will be generated and stored in the `db` folder , which is the **ChromaDB vector database**.
+
+## 📂 View Indexed Collections
+
+To list all collections currently embedded in your database, run:
+
+```bash
+curategpt collections list -p db
+```
+---
+
+# 🔍 Search Embedded CDEs and Ontologies
+
+Once embeddings are generated and stored in the vector DB (`db/`), you can use CurateGPT to run semantic search queries across any indexed collection.
+
+## Basic Search Command
+
+```bash
+curategpt search \
+  -p db \
+  -c <collection_name> \
+  "<your search query>"
+```
+- `-p db`: path to your ChromaDB folder  
+- `-c <collection_name>`: name of the collection to search (e.g., `ont_hp`, `cde_phenx`)  
+- `"..."`: your natural language or keyword-based query  
+
+## 🔎 Examples
+
+### 🔹 Search the Human Phenotype Ontology (`ont_hp`)
+
+```bash
+curategpt search -p db -c ont_hp "symptom involving hearing loss"
+```
+### 🔹 Search the RADx-UP CDE Schema (`cde_radx_up`)
+
+```bash
+curategpt search -p db -c cde_radx_up "participant's COVID-19 test history"
+```
+---
+

--- a/cde2vec/README.md
+++ b/cde2vec/README.md
@@ -27,62 +27,31 @@ Use the Makefile to index any supported ontology or schema:
 
 ### 🔹 Embed CDE Schemas
 
-| Make Target           | Description                                       |
-|----------------------|-------------------------------------------------|
-| `make embed-nih-cde`    | Embed NIH/NLM CDE schema from `linkml/nih_nlm_schema.yaml`      |
-| `make embed-phenx-cde`  | Embed PhenX CDE schema from `linkml/phenx_schema.yaml`          |
-| `make embed-radx-up-cde`| Embed RADx-UP CDE schema from `linkml/radx_up_schema.yaml`      |
+| Make Target              | Description                                                      |
+|--------------------------|------------------------------------------------------------------|
+| `make embed-nih-cde`     | Embed NIH/NLM CDE schema from `linkml/nih_nlm_schema.yaml`      |
+| `make embed-phenx-cde`   | Embed PhenX CDE schema from `linkml/phenx_schema.yaml`          |
+| `make embed-radx-up-cde` | Embed RADx-UP CDE schema from `linkml/radx_up_schema.yaml`      |
+| `make embed-heal-cde`    | Embed HEAL CDE schema from `linkml/heal_schema.yaml`            |
+| `make embed-connects-cde`| Embed CONNECTS CDE schema from `linkml/connects_schema.yaml`    |
 
-### 🔹 Embed Ontologies
+### 🔹 Search Examples
 
-| Make Target              | Description                  |
-|-------------------------|------------------------------|
-| `make embed-hp-ontology`    | Embed HPO (Human Phenotype Ontology)    |
-| `make embed-mondo-ontology` | Embed MONDO Disease Ontology             |
-| `make embed-cl-ontology`    | Embed CL (Cell Ontology)                  |
+#### Search the HEAL CDE Schema (`cde_heal`)
+```bash
+curategpt search -p db -c cde_heal "pain intensity numeric rating"
+```
+
+#### Search the CONNECTS CDE Schema (`cde_connects`)
+```bash
+curategpt search -p db -c cde_connects "COVID-19 symptom severity"
+```
 
 ---
 
 # Vector Store Location
 
-Embeddings for the following CDE Schemas and Ontologies will be generated and stored in the `db` folder , which is the **ChromaDB vector database**.
+Embeddings for the following CDE Schemas and Ontologies will be generated and stored at location `TBD`  , which is the **ChromaDB vector database**.
 
-## 📂 View Indexed Collections
-
-To list all collections currently embedded in your database, run:
-
-```bash
-curategpt collections list -p db
-```
----
-
-# 🔍 Search Embedded CDEs and Ontologies
-
-Once embeddings are generated and stored in the vector DB (`db/`), you can use CurateGPT to run semantic search queries across any indexed collection.
-
-## Basic Search Command
-
-```bash
-curategpt search \
-  -p db \
-  -c <collection_name> \
-  "<your search query>"
-```
-- `-p db`: path to your ChromaDB folder  
-- `-c <collection_name>`: name of the collection to search (e.g., `ont_hp`, `cde_phenx`)  
-- `"..."`: your natural language or keyword-based query  
-
-## 🔎 Examples
-
-### 🔹 Search the Human Phenotype Ontology (`ont_hp`)
-
-```bash
-curategpt search -p db -c ont_hp "symptom involving hearing loss"
-```
-### 🔹 Search the RADx-UP CDE Schema (`cde_radx_up`)
-
-```bash
-curategpt search -p db -c cde_radx_up "participant's COVID-19 test history"
-```
 ---
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,9 @@ setup(
         "pandas",    # DataFrame processing
         "openpyxl",  # Reading HEAL .xlsx files
         "requests",  # HTTP data fetching
-    ],
+        "curategpt",
+        "psutil",
+    ],  # Dependencies for the project
     entry_points={
         "console_scripts": [
             "cde2linkml = cde2linkml.cli:main",


### PR DESCRIPTION
Adds `cde2vec` module — semantic embedding pipeline for CDE schemas and OBO ontologies using CurateGPT and ChromaDB. Supports NIH NLM, PhenX, RADx-UP, HEAL, and CONNECTS LinkML schemas, plus HPO, MONDO, and CL ontologies.