### PR TITLE
Add PhenX Protocol and OMOP CDM support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,19 @@ HEAL_DIR     = data/cde-heal
 CONNECTS_DIR = data/cde-connects
 CONNECTS_URL = https://nhlbi-connects.org/data/documents/public/cde_cdes/CONNECTS_DD_V1.3.xlsx
 
+# Phenx protocols
+# Essential flags — override on the command line, e.g.:
+#   make download-phenx-protocols PHENX_LIMIT=10
+PHENX_SCRAPE_DIR = data/bundle-phenx
+PHENX_LIMIT  =
+PHENX_DELAY  = 0.8
+PHENX_RESUME =
+
+# OMOP CDM
+OMOP_DIR = data/cdm-omop
+OMOP_VERSION = 5.4
+OMOP_DELAY   = 0.5
+
 # --------------------------
 # Download
 # --------------------------
@@ -36,8 +49,23 @@ download-connects-cde:
 	mkdir -p $(CONNECTS_DIR)
 	curl -L -o $(CONNECTS_DIR)/CONNECTS_DD_V1.3.xlsx $(CONNECTS_URL)
 
-download-all: download-radx-up-cde download-nlm-cde download-phenx-cde download-heal-cde download-connects-cde
+download-phenx-protocols:
+	mkdir -p $(PHENX_SCRAPE_DIR)
+	python3 utils/phenx_scraper.py \
+	  $(if $(PHENX_LIMIT),--limit $(PHENX_LIMIT)) \
+	  --delay $(PHENX_DELAY) \
+	  $(if $(PHENX_RESUME),--resume) \
+	  --out $(PHENX_SCRAPE_DIR)/phenx_hierarchy.xlsx \
+	  --checkpoint-path $(PHENX_SCRAPE_DIR)/phenx_checkpoint.json
 
+download-omop-cdm:
+	mkdir -p $(OMOP_DIR)
+	python3 utils/omop_scraper.py \
+	  --version $(OMOP_VERSION) \
+	  --delay $(OMOP_DELAY) \
+	  --out $(OMOP_DIR)/omop_$(OMOP_VERSION).xlsx
+
+download-all: download-radx-up-cde download-nlm-cde download-phenx-cde download-heal-cde download-connects-cde download-phenx-protocols download-omop-cdm
 # --------------------------
 # Cleanup
 # --------------------------
@@ -57,8 +85,15 @@ clean-heal-cde:
 clean-connects-cde:
 	rm -rf $(CONNECTS_DIR)
 
+clean-phenx-protocols:
+	rm -rf $(PHENX_SCRAPE_DIR)
+
+clean-omop-cdm:
+	rm -rf $(OMOP_DIR)
+
 clean-all:
-	rm -rf $(RADX_DIR) $(NLM_DIR) $(PHENX_DIR) $(HEAL_DIR) $(CONNECTS_DIR)
+	rm -rf $(RADX_DIR) $(NLM_DIR) $(PHENX_DIR) $(HEAL_DIR) $(CONNECTS_DIR) $(PHENX_SCRAPE_DIR) $(OMOP_DIR)
+
 
 # --------------------------
 # Post-processing
@@ -184,6 +219,22 @@ embed-bdc-hchssol:
 	   -c bdc_hchssol \
 	   -m openai: \
 	   --source-locator linkml/bdc_hchssol_phs000810_schema.yaml \
+	   -p $(DB_PATH)
+
+embed-phenx-bundle:
+	$(CURATE) view index \
+	   --view linkml_schema \
+	   -c bundle_phenx \
+	   -m openai: \
+	   --source-locator linkml/phenx_bundle_schema.yaml \
+	   -p $(DB_PATH)
+
+embed-omop-cdm:
+	$(CURATE) view index \
+	   --view linkml_schema \
+	   -c cdm_omop \
+	   -m openai: \
+	   --source-locator linkml/omop_cdm_schema.yaml \
 	   -p $(DB_PATH)
 
 # CurateGPT Embedding Generation for OBO Ontologies

--- a/cde2linkml/README.md
+++ b/cde2linkml/README.md
@@ -4,7 +4,7 @@ This package standardizes Common Data Elements (CDEs) into the [LinkML](https://
 
 ## Features
 
-- Converts RADx-UP, NLM, PhenX, HEAL, and NHLBI CONNECTS CDE data into **LinkML-compatible schemas**.
+- Converts NIH CDE, Phenx toolkit, RADx-UP, NIH HEAL, NHLBI CONNECTS, PhenX protocols, and OMOP CDM data into **LinkML-compatible schemas**.
 - Provides a command-line interface (**CLI**) for easy data transformation.
 - Includes automated **data download** scripts via `make` commands for all CDE sources.
 
@@ -53,13 +53,15 @@ deactivate
 
 Makefile commands fetch data from all supported sources into their respective directories under `data/`.
 
-| Directory            | Source          |
-|----------------------|-----------------|
-| `data/cde-radx-up`  | RADx-UP         |
-| `data/cde-nlm`      | NIH NLM         |
-| `data/cde-phenx`    | PhenX           |
-| `data/cde-heal`     | NIH HEAL        |
-| `data/cde-connects` | NHLBI CONNECTS  |
+| Directory            | Source                   |
+|----------------------|--------------------------|
+| `data/cde-radx-up`   | RADx-UP                  |
+| `data/cde-nlm`       | NIH NLM (NIH CDE)        |
+| `data/cde-phenx`     | PhenX toolkit            |
+| `data/cde-heal`      | NIH HEAL                 |
+| `data/cde-connects`  | NHLBI CONNECTS           |
+| `data/bundle-phenx`  | PhenX Bundle (protocols) |
+| `data/cdm-omop`      | OMOP CDM                 |
 
 ### Download all sources
 
@@ -70,12 +72,16 @@ make download-all
 ### Download a specific source
 
 ```bash
-make download-radx-up-cde   # RADx-UP
-make download-nlm-cde        # NIH NLM
-make download-phenx-cde      # PhenX
-make download-heal-cde       # NIH HEAL (scrapes all 14 pages of the HEAL CDE Repository)
-make download-connects-cde   # NHLBI CONNECTS (single Excel file, multiple tabs)
+make download-radx-up-cde       # RADx-UP
+make download-nlm-cde           # NIH NLM
+make download-phenx-cde         # PhenX
+make download-heal-cde          # NIH HEAL (scrapes all 14 pages of the HEAL CDE Repository)
+make download-connects-cde      # NHLBI CONNECTS (single Excel file, multiple tabs)
+make download-phenx-protocols   # PhenX Bundle (scrapes full Collection→Domain→Protocol→Variable hierarchy)
+make download-omop-cdm          # OMOP CDM (default v5.4; override with OMOP_VERSION=5.3)
 ```
+
+Scraper scripts live in `utils/` (`phenx_scraper.py`, `omop_scraper.py`) and write `.xlsx`/`.csv` output directly into their `data/` directories.
 
 ### Clean downloaded data
 
@@ -86,6 +92,8 @@ make clean-nlm-cde
 make clean-phenx-cde
 make clean-heal-cde
 make clean-connects-cde
+make clean-phenx-protocols
+make clean-omop-cdm
 ```
 
 ---
@@ -100,13 +108,17 @@ cde2linkml [--radx-up] [--nih-nlm] [--phenx] [--heal] [options]
 
 ### Commands
 
-| Flag          | Description                                           | Output file                    |
-|---------------|-------------------------------------------------------|--------------------------------|
-| `--radx-up`   | Convert RADx-UP CDE data to LinkML                    | `linkml/radx_up_schema.yaml`   |
-| `--nih-nlm`   | Convert NIH NLM CDE data to LinkML                    | `linkml/nih_nlm_schema.yaml`   |
-| `--phenx`     | Convert PhenX CDE data to LinkML                      | `linkml/phenx_schema.yaml`     |
-| `--heal`      | Convert NIH HEAL CDE `.xlsx` files to LinkML          | `linkml/heal_schema.yaml`      |
-| `--connects`  | Convert NHLBI CONNECTS CDE Excel tabs to LinkML       | `linkml/connects_schema.yaml`  |
+| Flag             | Description                                              | Output file                        |
+|------------------|-----------------------------------------------------------|-------------------------------------|
+| `--radx-up`      | Convert RADx-UP CDE data to LinkML                        | `linkml/radx_up_schema.yaml`        |
+| `--nih-nlm`      | Convert NIH NLM CDE data to LinkML                        | `linkml/nih_nlm_schema.yaml`        |
+| `--phenx`        | Convert PhenX CDE data to LinkML                          | `linkml/phenx_schema.yaml`          |
+| `--heal`         | Convert NIH HEAL CDE `.xlsx` files to LinkML               | `linkml/heal_schema.yaml`           |
+| `--connects`     | Convert NHLBI CONNECTS CDE Excel tabs to LinkML            | `linkml/connects_schema.yaml`       |
+| `--phenx-bundle` | Convert PhenX Bundle xlsx (`data/bundle-phenx/`) to LinkML | `linkml/phenx_bundle_schema.yaml`   |
+| `--omop`         | Convert OMOP CDM xlsx (`data/cdm-omop/`) to LinkML         | `linkml/omop_cdm_schema.yaml`       |
+
+`--phenx-bundle` and `--omop` auto-discover the xlsx file in their respective `data/` directory, so no filename or version needs to be passed.
 
 Multiple flags can be combined in a single run:
 
@@ -118,7 +130,7 @@ cde2linkml --radx-up --phenx --heal
 
 | Option            | Description                                                              |
 |-------------------|--------------------------------------------------------------------------|
-| `--input-folder`  | Path to input data folder. Overrides the default `data/cde-<source>` path. |
+| `--input-folder`  | Path to input data folder/file. Overrides the default `data/cde-<source>` path (or the auto-discovered xlsx for `--phenx-bundle`/`--omop`). |
 | `--output-folder` | Path to output directory for LinkML YAML files. Defaults to `linkml/`.  |
 
 ### Examples
@@ -129,10 +141,16 @@ Convert HEAL CDEs using default paths:
 cde2linkml --heal
 ```
 
+Convert PhenX Bundle and OMOP CDM:
+
+```bash
+cde2linkml --phenx-bundle --omop
+```
+
 Convert all sources at once:
 
 ```bash
-cde2linkml --radx-up --nih-nlm --phenx --heal --connects
+cde2linkml --radx-up --nih-nlm --phenx --heal --connects --phenx-bundle --omop
 ```
 
 Use a custom input and output directory:
@@ -158,15 +176,15 @@ cde2linkml -h
 ### CDE Repositories — Source Column Mapping
 
 | LinkML Fields    | HEAL                                       | CONNECTS                                                                           | NIH NLM                                                     | RADx-UP                                | PhenX                         |
-|------------------|--------------------------------------------|------------------------------------------------------------------------------------|-------------------------------------------------------------|----------------------------------------|-------------------------------|
-| `class.name`     | Filename minus `-cde`                      | Tab name                                                                           | `steward`                                                   | `Form Name`                            | Filename minus extension      |
-| `slot.key`       | `Variable Name`                            | `Element`                                                                          | `designations[0].designation`                               | `Variable / Field Name`                | `VARNAME`                     |
-| `slot.title`     | `CDE Name`                                 | `Variable Label`                                                                   | `designations[0].designation`                               | `Variable / Field Name` (human-readable) | —                             |
-| `slot.description` | `Definition`                               | `Question`                                                                         | `definitions[0].definition`                                 | `Field Label`                          | `VARDESC`                     |
-| `slot.range`     | `Data Type`                                | `Variable Type`                                                                    | `valueDomain.datatype`                                      | `Text Validation Type OR Show Slider Number` | `TYPE`                        |
-| `slot.minimum_value` | —                                          | —                                                                                  | —                                                           | `Text Validation Min`                  | `MIN`                         |
-| `slot.maximum_value` | —                                          | —                                                                                  | —                                                           | `Text Validation Max`                  | `MAX`                         |
-| `slot_uri`       | —                                          | —                                                                                  | `tinyId`                                                    | —                                      | —                             |
+|------------------|--------------------------------------------|------------------------------------------------------------------------------------|---------------------------------------------------------------|-----------------------------------------|--------------------------------|
+| `class.name`     | Filename minus `-cde`                      | Tab name                                                                           | `steward`                                                    | `Form Name`                             | Filename minus extension       |
+| `slot.key`       | `Variable Name`                            | `Element`                                                                          | `designations[0].designation`                                | `Variable / Field Name`                 | `VARNAME`                      |
+| `slot.title`     | `CDE Name`                                 | `Variable Label`                                                                   | `designations[0].designation`                                | `Variable / Field Name` (human-readable) | —                              |
+| `slot.description` | `Definition`                               | `Question`                                                                         | `definitions[0].definition`                                  | `Field Label`                           | `VARDESC`                      |
+| `slot.range`     | `Data Type`                                | `Variable Type`                                                                    | `valueDomain.datatype`                                       | `Text Validation Type OR Show Slider Number` | `TYPE`                     |
+| `slot.minimum_value` | —                                          | —                                                                                  | —                                                            | `Text Validation Min`                   | `MIN`                          |
+| `slot.maximum_value` | —                                          | —                                                                                  | —                                                            | `Text Validation Max`                   | `MAX`                          |
+| `slot_uri`       | —                                          | —                                                                                  | `tinyId`                                                     | —                                        | —                              |
 | `slot.annotations` | `Additional Notes (Question Text)`         | `Variable`, `Variable Label`, `Implementation Notes`                               | `designations[*]` tag `Preferred Question Text`, `registrationState.registrationStatus`, `registrationState.administrativeStatus`, `copyrightStatus`, `nihEndorsed`, `properties[Tags/Keywords]`, `stewardOrg.name`, `sources[*].sourceName`, `classification[*].elements[*].name`, `partOfBundles`, `created` | — | `VARIABLE_SOURCE`, `SOURCE_VARIABLE_ID`, `COMMENT1` |
 | `enum.permissible_values` | `PV Description` (`;`-separated, `1 = Label; 2 = Label`) | `Response Options / Derivation` (`\|`-separated, auto-detected regardless of `Variable Type`) | `valueDomain.permissibleValues` (with `meaning` from `conceptSource`) | `Choices, Calculations, OR Slider Labels` (`\|`-separated, `1, Label` format) | `VALUES` + columns to right (`\|`-separated) |
 | **Not mapped**   | `CRF Question #`, `Short Description`, `Permissible Values`, `Disease Specific Instructions`, `Disease Specific References`, `Population`, `Classification`, `CRF Name`, `External Id CDISC`, `Notes` | `IP`, `OP`, `D`, `N`, `Length`, `BDC ID`, `CDISC Mapping` | `createdBy`, `dataElementConcept`, `objectClass`, `ids`, `attachments`, `history`, `views`, `referenceDocuments`, `dataSets`, `derivationRules`, `changeNote`, `archived`, `cdeTinyIds` | `Section Header`, `Field Type`, `Field Note`, `Identifier`, `Branching Logic`, `Required Field`, `Custom Alignment`, `Question Number`, `Matrix Group Name`, `Matrix Ranking`, `Field Annotation` | `DOCFILE`, `UNITS`, `RESOLUTION`, `COMMENT2`, `VARIABLE_MAPPING`, `UNIQUEKEY`, `COLLINTERVAL`, `ORDER` |
@@ -174,18 +192,18 @@ cde2linkml -h
 ### CDE Repositories — Schema Statistics
 
 | Source   | Classes | Slots  | Enums | Data Downloaded | Schema Generated |
-|----------|---------|--------|-------|-----------------|------------------|
-| NIH NLM  | 19      | 22,215 | 3,432 | 03-27-2026      | 03-27-2026       |
-| PhenX    | 848     | 30,659 | 2,362 | 03-27-2026      | 03-27-2026       |
-| HEAL     | 264     | 5,224  | 386   | 03-27-2026      | 03-27-2026       |
-| CONNECTS | 16      | 356    | 52    | 03-27-2026      | 03-27-2026       |
-| RADx-UP  | 30      | 1,097  | 150   | 2025            | 2025                |
-| **Total**| **1,177** | **59,551** | **6,382** |                 |                  |
+|----------|---------|--------|-------|------------------|-------------------|
+| NIH NLM  | 19      | 22,215 | 3,432 | 03-27-2026       | 03-27-2026        |
+| PhenX    | 848     | 30,659 | 2,362 | 03-27-2026       | 03-27-2026        |
+| HEAL     | 264     | 5,224  | 386   | 03-27-2026       | 03-27-2026        |
+| CONNECTS | 16      | 356    | 52    | 03-27-2026       | 03-27-2026        |
+| RADx-UP  | 30      | 1,097  | 150   | 2025             | 2025              |
+| **Total**| **1,177** | **59,551** | **6,382** |              |                   |
 
 ### NIDDK Data Dictionaries — Source Column Mapping
 
 |                           | CureGN                                              | KPMP                                                                              | NEPTUNE                                                        | CRIC                                                                                      |
-|---------------------------|-----------------------------------------------------|-----------------------------------------------------------------------------------|----------------------------------------------------------------|-------------------------------------------------------------------------------------------|
+|---------------------------|-------------------------------------------------------|-------------------------------------------------------------------------------------|--------------------------------------------------------------|----------------------------------------------------------------------------------------|
 | Class name                | `DatasetName` (PascalCase)                          | `Form Name` (PascalCase)                                                          | Tab name (PascalCase)                                          | `DATASET` (PascalCase)                                                                    |
 | Slot key (`snake_case`)   | `VarName`                                           | `Variable / Field Name`                                                           | `Variable`                                                     | `Variable_Name`                                                                           |
 | `slot.title`              | —                                                   | `Variable / Field Name` (human-readable)                                          | —                                                              | —                                                                                         |
@@ -202,9 +220,9 @@ cde2linkml -h
 ### NIDDK Data Dictionaries — Schema Statistics
 
 | Source   | Classes | Slots      | Enums         | Data Downloaded | Schema Generated |
-|----------|---------|------------|---------------|-----------------|------------------|
-| CureGN   | 49      | 2,242      | 183           | —               | 04-07-2026       |
-| KPMP     | 62      | 5,094      | 358           | —               | 04-07-2026       |
-| NEPTUNE  | 34      | 1,906      | 150 (stubs)   | —               | 04-07-2026       |
-| CRIC     | 11      | 1,191      | 879 (stubs)   | —               | 04-07-2026       |
-| **Total**| **156** | **10,433** | **1,570**     |                 |                  |
+|----------|---------|------------|---------------|-----------------|-------------------|
+| CureGN   | 49      | 2,242      | 183           | —                | 04-07-2026        |
+| KPMP     | 62      | 5,094      | 358           | —                | 04-07-2026        |
+| NEPTUNE  | 34      | 1,906      | 150 (stubs)   | —                | 04-07-2026        |
+| CRIC     | 11      | 1,191      | 879 (stubs)   | —                | 04-07-2026        |
+| **Total**| **156** | **10,433** | **1,570**     |                  |                   |

--- a/cde2linkml/bundle_phenx2linkml.py
+++ b/cde2linkml/bundle_phenx2linkml.py
@@ -1,0 +1,158 @@
+"""
+cde2linkml/bundle_phenx2linkml.py
+==================================
+Convert phenx_2026.xlsx into a LinkML YAML schema for the bundle_phenx
+ChromaDB collection.
+
+Each xlsx variable becomes one LinkML slot:
+    slot name   : snake_case of Variable Name
+    description : Variable Description  ← CURATE embeds this
+    annotations :
+        source               : PhenX
+        source_variable_id   : PX570101080100
+        protocol_id          : 570101
+        protocol_name        : Body Mass Index
+        domain_id            : 230000
+        domain_name          : Obesity
+        sub_collection_id    : 33
+        sub_collection_name  : Behaviors and Risks
+        collection_id        : 8
+        collection_name      : COVID-19 Research Collection
+
+Full hierarchy supported:
+    Bundles → bundle_phenx → Collection → SubCollection → Domain → Protocol
+"""
+
+import os
+import re
+import yaml
+import pandas as pd
+
+
+def _to_snake_case(text: str) -> str:
+    text = str(text).strip()
+    text = re.sub(r'[\s\-\.]+', '_', text)
+    text = re.sub(r'[^a-zA-Z0-9_]', '', text)
+    text = re.sub(r'_+', '_', text).strip('_')
+    return text.lower()
+
+
+class _Dumper(yaml.SafeDumper):
+    def represent_str(self, data: str):
+        return self.represent_scalar('tag:yaml.org,2002:str', data)
+
+_Dumper.add_representer(str, _Dumper.represent_str)
+
+
+def s(v) -> str:
+    return "" if (v is None or (isinstance(v, float) and v != v)) \
+           else str(v).strip().rstrip('.0') if str(v).endswith('.0') else str(v).strip()
+
+
+def process_phenx_bundle(input_file: str, output_file: str) -> None:
+    """
+    Read phenx_2026.xlsx and write a LinkML YAML schema to output_file.
+    """
+    df = pd.read_excel(input_file, sheet_name="Variables (CDEs)", header=1)
+    df.columns = df.columns.str.strip()
+
+    # Also load Protocols sheet for IDs not in Variables sheet
+    df_p = pd.read_excel(input_file, sheet_name="Protocols", header=1)
+    df_p.columns = df_p.columns.str.strip()
+
+    # Build protocol_id → full hierarchy IDs lookup from Protocols sheet
+    proto_lookup = {}
+    for _, row in df_p.iterrows():
+        pid = s(row.get("Protocol ID", ""))
+        if pid:
+            proto_lookup[pid] = {
+                "domain_id":           s(row.get("Domain ID",           "")),
+                "domain_name":         s(row.get("Domain Name",         "")),
+                "sub_collection_id":   s(row.get("Sub-collection ID",   "")),
+                "sub_collection_name": s(row.get("Sub-collection Name", "")),
+                "collection_id":       s(row.get("Collection ID",       "")),
+                "collection_name":     s(row.get("Collection Name",     "")),
+                "protocol_name":       s(row.get("Protocol Name",       "")),
+                "protocol_url":        s(row.get("Protocol URL",        "")),
+            }
+
+    df = df[df["Variable Name"].notna()].reset_index(drop=True)
+
+    schema = {
+        "id":             "https://example.org/schemas/phenx_bundle",
+        "name":           "PhenXBundleSchema",
+        "description": (
+            "LinkML schema for PhenX bundle variables. "
+            "Generated from phenx_2026.xlsx by bundle_phenx2linkml.py. "
+            "Supports full hierarchy: "
+            "Bundles → bundle_phenx → Collection → SubCollection → Domain → Protocol."
+        ),
+        "version":        "1.0.0",
+        "default_range":  "string",
+        "license":        "https://creativecommons.org/publicdomain/zero/1.0/",
+        "imports":        ["linkml:types"],
+        "prefixes": {
+            "linkml": "https://w3id.org/linkml/",
+            "phenx":  "https://www.phenxtoolkit.org/",
+        },
+        "default_prefix": "phenx",
+        "slots": {},
+    }
+
+    seen: set = set()
+    skipped = 0
+
+    for _, row in df.iterrows():
+        def g(col):
+            v = row.get(col, "")
+            return "" if (v is None or (isinstance(v, float) and v != v)) \
+                   else str(v).strip()
+
+        var_name = g("Variable Name")
+        var_desc = g("Variable Description")
+        var_id   = g("Variable ID (CDE ID)")
+        proto_id = g("Protocol ID")
+
+        if not var_name:
+            skipped += 1
+            continue
+
+        slot_key = _to_snake_case(var_name)
+        if not slot_key or slot_key in seen:
+            skipped += (1 if not slot_key else 0)
+            continue
+        seen.add(slot_key)
+
+        description = var_desc or var_name
+
+        # Get full hierarchy from protocol lookup
+        ph = proto_lookup.get(proto_id, {})
+
+        annotations = {"source": "PhenX"}
+        if var_id:                          annotations["source_variable_id"]   = var_id
+        if proto_id:                        annotations["protocol_id"]           = proto_id
+        if ph.get("protocol_name"):         annotations["protocol_name"]         = ph["protocol_name"]
+        if ph.get("protocol_url"):          annotations["protocol_url"]          = ph["protocol_url"]
+        if ph.get("domain_id"):             annotations["domain_id"]             = ph["domain_id"]
+        if ph.get("domain_name"):           annotations["domain_name"]           = ph["domain_name"]
+        if ph.get("sub_collection_id"):     annotations["sub_collection_id"]     = ph["sub_collection_id"]
+        if ph.get("sub_collection_name"):   annotations["sub_collection_name"]   = ph["sub_collection_name"]
+        if ph.get("collection_id"):         annotations["collection_id"]         = ph["collection_id"]
+        if ph.get("collection_name"):       annotations["collection_name"]       = ph["collection_name"]
+
+        schema["slots"][slot_key] = {
+            "description": description,
+            "annotations": annotations,
+        }
+
+    os.makedirs(os.path.dirname(output_file) or ".", exist_ok=True)
+
+    raw = yaml.dump(schema, Dumper=_Dumper, sort_keys=False,
+                    default_flow_style=False, allow_unicode=True)
+    raw = raw.replace(": null\n", ":\n")
+
+    with open(output_file, "w", encoding="utf-8") as fh:
+        fh.write(raw)
+
+    print(f"PhenX bundle LinkML schema saved to {output_file} "
+          f"({len(schema['slots']):,} slots, {skipped} skipped).")

--- a/cde2linkml/cli.py
+++ b/cde2linkml/cli.py
@@ -1,33 +1,45 @@
 import argparse
+import glob
 import os
 
-from cde2linkml.radxup2linkml import process_radxup_csv
-from cde2linkml.nlm2linkml import process_nih_nlm_json
-from cde2linkml.phenx2linkml import process_phenx_folder
-from cde2linkml.heal2linkml import process_heal_folder
-from cde2linkml.connects2linkml import process_connects_file
-from cde2linkml.curegn2linkml import process_curegn_file
-from cde2linkml.kpmp2linkml import process_kpmp_folder
-from cde2linkml.neptune2linkml import process_neptune_file
-from cde2linkml.cric2linkml import process_cric_folder
-from cde2linkml.bdc2linkml import process_bdc_folder
+from cde2linkml.radxup2linkml       import process_radxup_csv
+from cde2linkml.nlm2linkml          import process_nih_nlm_json
+from cde2linkml.phenx2linkml        import process_phenx_folder
+from cde2linkml.heal2linkml         import process_heal_folder
+from cde2linkml.connects2linkml     import process_connects_file
+from cde2linkml.curegn2linkml       import process_curegn_file
+from cde2linkml.kpmp2linkml         import process_kpmp_folder
+from cde2linkml.neptune2linkml      import process_neptune_file
+from cde2linkml.cric2linkml         import process_cric_folder
+from cde2linkml.bdc2linkml          import process_bdc_folder
+from cde2linkml.bundle_phenx2linkml import process_phenx_bundle
+from cde2linkml.omop2linkml         import process_omop_bundle
+
 
 DEFAULT_INPUTS = {
-    "radx-up":  "data/cde-radx-up",
-    "nih-nlm":  "data/cde-nlm",
-    "phenx":    "data/cde-phenx",
-    "heal":     "data/cde-heal",
-    "connects": "data/cde-connects",
-    "curegn":   "data/dd-niddk-curegn",
-    "kpmp":     "data/dd-niddk-kpmp",
-    "neptune":  "data/dd-niddk-neptune",
-    "cric":     "data/dd-niddk-cric",
-    "bdc":      "data/BDC",
+    "radx-up":      "data/cde-radx-up",
+    "nih-nlm":      "data/cde-nlm",
+    "phenx":        "data/cde-phenx",
+    "heal":         "data/cde-heal",
+    "connects":     "data/cde-connects",
+    "curegn":       "data/dd-niddk-curegn",
+    "kpmp":         "data/dd-niddk-kpmp",
+    "neptune":      "data/dd-niddk-neptune",
+    "cric":         "data/dd-niddk-cric",
+    "bdc":          "data/BDC",
+    # These two are *folders* — the actual xlsx filename is auto-discovered
+    # at runtime by _resolve_xlsx_default(), since it varies (CDM version,
+    # scrape date, etc.) and shouldn't be hardcoded here.
+    "phenx-bundle": "data/bundle-phenx",
+    "omop":         "data/cdm-omop",
 }
 
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Input validators
+# ─────────────────────────────────────────────────────────────────────────────
+
 def check_and_prompt_folder(folder_path, download_message):
-    """Check if folder exists; if not, prompt user to download."""
     if not os.path.exists(folder_path):
         print(f"Error: Folder '{folder_path}' does not exist.")
         print("Please download the data by running 'make' commands as follows:")
@@ -41,126 +53,227 @@ def check_and_prompt_folder(folder_path, download_message):
     return True
 
 
-def ensure_output_folder(output_folder):
-    """Ensure the output folder exists."""
-    os.makedirs(output_folder, exist_ok=True)
+def check_and_prompt_file(file_path, download_message):
+    if not file_path or not os.path.exists(file_path):
+        print(f"Error: File '{file_path}' does not exist.")
+        print(download_message)
+        return False
+    return True
 
 
-def process_command(command, input_folder, output_folder):
-    """Process the selected command with input and output folders."""
+def _resolve_xlsx_default(folder_path):
+    """
+    Return the most recently modified .xlsx file in folder_path, or None if
+    the folder is missing/empty. Used so DEFAULT_INPUTS doesn't need to
+    hardcode a version- or date-specific filename (e.g. omop_5.4.xlsx,
+    phenx_2026.xlsx) — any xlsx dropped in the folder is picked up.
+    """
+    if not os.path.isdir(folder_path):
+        return None
+    candidates = glob.glob(os.path.join(folder_path, "*.xlsx"))
+    if not candidates:
+        return None
+    if len(candidates) > 1:
+        print(
+            f"Note: multiple .xlsx files found in '{folder_path}', "
+            f"using the most recently modified one. "
+            f"Pass --input-folder to pick a specific file."
+        )
+    return max(candidates, key=os.path.getmtime)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Dispatch
+# ─────────────────────────────────────────────────────────────────────────────
+
+def process_command(command, input_path, output_folder):
+
     if command == "radx-up":
-        if not check_and_prompt_folder(input_folder, "Download RADx-UP data to 'data/cde-radx-up'."):
+        if not check_and_prompt_folder(input_path, "Download RADx-UP data to 'data/cde-radx-up'."):
             return
-        process_radxup_csv(input_folder, os.path.join(output_folder, "radx_up_schema.yaml"))
+        process_radxup_csv(input_path, os.path.join(output_folder, "radx_up_schema.yaml"))
 
     elif command == "nih-nlm":
-        if not check_and_prompt_folder(input_folder, "Download NIH NLM data to 'data/cde-nlm'."):
+        if not check_and_prompt_folder(input_path, "Download NIH NLM data to 'data/cde-nlm'."):
             return
-        process_nih_nlm_json(input_folder, os.path.join(output_folder, "nih_nlm_schema.yaml"))
+        process_nih_nlm_json(input_path, os.path.join(output_folder, "nih_nlm_schema.yaml"))
 
     elif command == "phenx":
-        if not check_and_prompt_folder(input_folder, "Download PhenX data to 'data/cde-phenx'."):
+        if not check_and_prompt_folder(input_path, "Download PhenX data to 'data/cde-phenx'."):
             return
-        process_phenx_folder(input_folder, os.path.join(output_folder, "phenx_schema.yaml"))
+        process_phenx_folder(input_path, os.path.join(output_folder, "phenx_schema.yaml"))
 
     elif command == "heal":
-        if not check_and_prompt_folder(input_folder, "Download HEAL data to 'data/cde-heal'."):
+        if not check_and_prompt_folder(input_path, "Download HEAL data to 'data/cde-heal'."):
             return
-        process_heal_folder(input_folder, os.path.join(output_folder, "heal_schema.yaml"))
+        process_heal_folder(input_path, os.path.join(output_folder, "heal_schema.yaml"))
 
     elif command == "connects":
-        if not check_and_prompt_folder(input_folder, "Download CONNECTS data to 'data/cde-connects'."):
+        if not check_and_prompt_folder(input_path, "Download CONNECTS data to 'data/cde-connects'."):
             return
-        process_connects_file(input_folder, os.path.join(output_folder, "connects_schema.yaml"))
+        process_connects_file(input_path, os.path.join(output_folder, "connects_schema.yaml"))
 
     elif command == "curegn":
-        if not check_and_prompt_folder(input_folder, "Place CureGN xlsx file in 'data/dd-niddk-curegn'."):
+        if not check_and_prompt_folder(input_path, "Place CureGN xlsx file in 'data/dd-niddk-curegn'."):
             return
-        process_curegn_file(input_folder, os.path.join(output_folder, "curegn_schema.yaml"))
+        process_curegn_file(input_path, os.path.join(output_folder, "curegn_schema.yaml"))
 
     elif command == "kpmp":
-        if not check_and_prompt_folder(input_folder, "Place KPMP CSV file(s) in 'data/dd-niddk-kpmp'."):
+        if not check_and_prompt_folder(input_path, "Place KPMP CSV file(s) in 'data/dd-niddk-kpmp'."):
             return
-        process_kpmp_folder(input_folder, os.path.join(output_folder, "kpmp_schema.yaml"))
+        process_kpmp_folder(input_path, os.path.join(output_folder, "kpmp_schema.yaml"))
 
     elif command == "neptune":
-        if not check_and_prompt_folder(input_folder, "Place NEPTUNE xlsx file in 'data/dd-niddk-neptune'."):
+        if not check_and_prompt_folder(input_path, "Place NEPTUNE xlsx file in 'data/dd-niddk-neptune'."):
             return
-        process_neptune_file(input_folder, os.path.join(output_folder, "neptune_schema.yaml"))
+        process_neptune_file(input_path, os.path.join(output_folder, "neptune_schema.yaml"))
 
     elif command == "cric":
-        if not check_and_prompt_folder(input_folder, "Place CRIC xlsx file(s) in 'data/dd-niddk-cric'."):
+        if not check_and_prompt_folder(input_path, "Place CRIC xlsx file(s) in 'data/dd-niddk-cric'."):
             return
-        process_cric_folder(input_folder, os.path.join(output_folder, "cric_schema.yaml"))
+        process_cric_folder(input_path, os.path.join(output_folder, "cric_schema.yaml"))
 
     elif command == "bdc":
-        if not check_and_prompt_folder(input_folder, "Place BDC_*.csv files in 'data/BDC'."):
+        if not check_and_prompt_folder(input_path, "Place BDC_*.csv files in 'data/BDC'."):
             return
-        # BDC produces one YAML per CSV; output_folder is passed directly
-        process_bdc_folder(input_folder, output_folder)
+        process_bdc_folder(input_path, output_folder)
 
+    elif command == "phenx-bundle":
+        if not check_and_prompt_file(
+            input_path,
+            "No xlsx file found in 'data/bundle-phenx'.\n"
+            "Run: make download-phenx-protocols\n"
+            "     (Or pass --input-folder with the full path to an existing xlsx file.)"
+        ):
+            return
+        process_phenx_bundle(
+            input_path,
+            os.path.join(output_folder, "phenx_bundle_schema.yaml")
+        )
+
+    elif command == "omop":
+        if not check_and_prompt_file(
+            input_path,
+            "No xlsx file found in 'data/cdm-omop'.\n"
+            "Run: make download-omop-cdm OMOP_VERSION=5.4\n"
+            "     (Or pass --input-folder with the full path to an existing xlsx file.)"
+        ):
+            return
+        process_omop_bundle(
+            input_path,
+            os.path.join(output_folder, "omop_cdm_schema.yaml")
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# CLI
+# ─────────────────────────────────────────────────────────────────────────────
 
 def main():
-    parser = argparse.ArgumentParser(description="Generate LinkML schemas from CDE data.")
+    parser = argparse.ArgumentParser(
+        description="Generate LinkML schemas from CDE data."
+    )
 
-    parser.add_argument('--radx-up',   action='store_true', help="Process RADx-UP CDE data")
-    parser.add_argument('--nih-nlm',   action='store_true', help="Process NIH NLM CDE data")
-    parser.add_argument('--phenx',     action='store_true', help="Process PhenX CDE data")
-    parser.add_argument('--heal',      action='store_true', help="Process HEAL CDE data")
-    parser.add_argument('--connects',  action='store_true', help="Process NHLBI CONNECTS CDE data")
-    parser.add_argument('--curegn',    action='store_true', help="Process CureGN SAF data dictionary")
-    parser.add_argument('--kpmp',      action='store_true', help="Process KPMP data dictionary")
-    parser.add_argument('--neptune',   action='store_true', help="Process NEPTUNE data dictionary")
-    parser.add_argument('--cric',      action='store_true', help="Process CRIC data dictionary")
-    parser.add_argument('--bdc',       action='store_true', help="Process BioData Catalyst (BDC) CSV data dictionaries")
+    # ── source flags ──────────────────────────────────────────────────────────
+    parser.add_argument("--radx-up",      action="store_true", help="Process RADx-UP CDE data")
+    parser.add_argument("--nih-nlm",      action="store_true", help="Process NIH NLM CDE data")
+    parser.add_argument("--phenx",        action="store_true", help="Process PhenX CDE data (CSV files)")
+    parser.add_argument("--heal",         action="store_true", help="Process HEAL CDE data")
+    parser.add_argument("--connects",     action="store_true", help="Process NHLBI CONNECTS CDE data")
+    parser.add_argument("--curegn",       action="store_true", help="Process CureGN SAF data dictionary")
+    parser.add_argument("--kpmp",         action="store_true", help="Process KPMP data dictionary")
+    parser.add_argument("--neptune",      action="store_true", help="Process NEPTUNE data dictionary")
+    parser.add_argument("--cric",         action="store_true", help="Process CRIC data dictionary")
+    parser.add_argument("--bdc",          action="store_true",
+                        help="Process BioData Catalyst (BDC) CSV data dictionaries")
+    parser.add_argument("--phenx-bundle", action="store_true",
+                        help=(
+                            "Generate bundle_phenx LinkML schema from the xlsx produced by "
+                            "'make download-phenx-protocols' (auto-discovered in "
+                            "data/bundle-phenx/). "
+                            "Output: linkml/phenx_bundle_schema.yaml. "
+                            "Used to build the bundle_phenx ChromaDB collection with CURATE "
+                            "for mapping all other sources against PhenX protocols."
+                        ))
+    parser.add_argument("--omop",         action="store_true",
+                        help=(
+                            "Generate cdm_omop LinkML schema from the xlsx produced by "
+                            "'make download-omop-cdm' (auto-discovered in data/cdm-omop/, "
+                            "any CDM version). "
+                            "Output: linkml/omop_cdm_schema.yaml. "
+                            "Used to build the cdm_omop ChromaDB collection with CURATE "
+                            "for mapping all other sources against OMOP CDM columns."
+                        ))
 
-    parser.add_argument('--input-folder',  type=str, default=None,    help="Input folder (overrides default)")
-    parser.add_argument('--output-folder', type=str, default="linkml", help="Output folder (default: linkml/)")
+    # ── path overrides ────────────────────────────────────────────────────────
+    parser.add_argument(
+        "--input-folder", type=str, default=None,
+        help=(
+            "Input path override (default varies by source). "
+            "For --phenx-bundle: path to a specific xlsx file "
+            "(default: auto-discovered in data/bundle-phenx/). "
+            "For --omop: path to a specific xlsx file "
+            "(default: auto-discovered in data/cdm-omop/). "
+            "For all others: path to folder containing source data."
+        )
+    )
+    parser.add_argument(
+        "--output-folder", type=str, default="linkml",
+        help="Output folder for generated YAML files (default: linkml/)"
+    )
 
     args = parser.parse_args()
 
+    # ── guard: at least one flag required ─────────────────────────────────────
     if not any([
         args.radx_up, args.nih_nlm, args.phenx, args.heal, args.connects,
         args.curegn, args.kpmp, args.neptune, args.cric, args.bdc,
+        args.phenx_bundle, args.omop,
     ]):
         print(
-            "Error: No dataset flag provided. Use '--radx-up', '--nih-nlm', '--phenx', "
-            "'--heal', '--connects', '--curegn', '--kpmp', '--neptune', '--cric', or '--bdc'."
+            "Error: No dataset flag provided. Use one or more of:\n"
+            "  --radx-up  --nih-nlm  --phenx  --heal  --connects\n"
+            "  --curegn   --kpmp     --neptune --cric  --bdc\n"
+            "  --phenx-bundle  --omop"
         )
         parser.print_help()
         return
 
-    ensure_output_folder(args.output_folder)
+    os.makedirs(args.output_folder, exist_ok=True)
 
+    # ── dispatch ──────────────────────────────────────────────────────────────
     if args.radx_up:
-        process_command("radx-up", args.input_folder or DEFAULT_INPUTS["radx-up"], args.output_folder)
-
+        process_command("radx-up",  args.input_folder or DEFAULT_INPUTS["radx-up"],  args.output_folder)
     if args.nih_nlm:
-        process_command("nih-nlm", args.input_folder or DEFAULT_INPUTS["nih-nlm"], args.output_folder)
-
+        process_command("nih-nlm",  args.input_folder or DEFAULT_INPUTS["nih-nlm"],  args.output_folder)
     if args.phenx:
-        process_command("phenx", args.input_folder or DEFAULT_INPUTS["phenx"], args.output_folder)
-
+        process_command("phenx",    args.input_folder or DEFAULT_INPUTS["phenx"],    args.output_folder)
     if args.heal:
-        process_command("heal", args.input_folder or DEFAULT_INPUTS["heal"], args.output_folder)
-
+        process_command("heal",     args.input_folder or DEFAULT_INPUTS["heal"],     args.output_folder)
     if args.connects:
         process_command("connects", args.input_folder or DEFAULT_INPUTS["connects"], args.output_folder)
-
     if args.curegn:
-        process_command("curegn", args.input_folder or DEFAULT_INPUTS["curegn"], args.output_folder)
-
+        process_command("curegn",   args.input_folder or DEFAULT_INPUTS["curegn"],   args.output_folder)
     if args.kpmp:
-        process_command("kpmp", args.input_folder or DEFAULT_INPUTS["kpmp"], args.output_folder)
-
+        process_command("kpmp",     args.input_folder or DEFAULT_INPUTS["kpmp"],     args.output_folder)
     if args.neptune:
-        process_command("neptune", args.input_folder or DEFAULT_INPUTS["neptune"], args.output_folder)
-
+        process_command("neptune",  args.input_folder or DEFAULT_INPUTS["neptune"],  args.output_folder)
     if args.cric:
-        process_command("cric", args.input_folder or DEFAULT_INPUTS["cric"], args.output_folder)
-
+        process_command("cric",     args.input_folder or DEFAULT_INPUTS["cric"],     args.output_folder)
     if args.bdc:
-        process_command("bdc", args.input_folder or DEFAULT_INPUTS["bdc"], args.output_folder)
+        process_command("bdc",      args.input_folder or DEFAULT_INPUTS["bdc"],      args.output_folder)
+    if args.phenx_bundle:
+        process_command(
+            "phenx-bundle",
+            args.input_folder or _resolve_xlsx_default(DEFAULT_INPUTS["phenx-bundle"]),
+            args.output_folder,
+        )
+    if args.omop:
+        process_command(
+            "omop",
+            args.input_folder or _resolve_xlsx_default(DEFAULT_INPUTS["omop"]),
+            args.output_folder,
+        )
 
 
 if __name__ == "__main__":

--- a/cde2linkml/omop2linkml.py
+++ b/cde2linkml/omop2linkml.py
@@ -1,0 +1,217 @@
+"""
+cde2linkml/omop2linkml.py
+=========================
+Convert omop_{version}.xlsx into a LinkML YAML schema for the cdm_omop
+ChromaDB collection.
+
+Parallel to bundle_phenx2linkml.py — reads the "Columns (CDEs)" sheet
+produced by omop_scraper.py and emits one LinkML slot per column, with
+the full CDM hierarchy encoded as separate annotations.
+
+Each xlsx column becomes one LinkML slot:
+
+    slot name   : {table_name}__{column_name}   e.g. person__birth_datetime
+    description : Column Description             ← CURATE embeds this
+    annotations :
+        source               : OMOP_CDM
+        source_variable_id   : OMOPColumn_PERSON__birth_datetime
+        cdm_version          : 5.4
+        column_name          : birth_datetime
+        datatype             : datetime
+        is_required          : No
+        is_primary_key       : No
+        is_foreign_key       : No
+        fk_table             : (empty)
+        fk_domain            : (empty)
+        table_name           : PERSON
+        table_group          : Clinical_Data_Tables
+        schema               : CDM
+        table_url            : https://ohdsi.github.io/CommonDataModel/cdm54.html#person
+        table_description    : This table serves as the central identity …
+
+Full hierarchy (parallel to PhenX):
+    TableGroup  ↔  Collection
+    Table       ↔  SubCollection / Protocol
+    Column      ↔  Variable (CDE)
+"""
+
+import os
+import re
+import yaml
+import pandas as pd
+
+
+def _to_snake(text: str) -> str:
+    text = str(text).strip()
+    text = re.sub(r'[\s\-\.]+', '_', text)
+    text = re.sub(r'[^a-zA-Z0-9_]', '', text)
+    text = re.sub(r'_+', '_', text).strip('_')
+    return text.lower()
+
+
+class _Dumper(yaml.SafeDumper):
+    def represent_str(self, data: str):
+        return self.represent_scalar('tag:yaml.org,2002:str', data)
+
+_Dumper.add_representer(str, _Dumper.represent_str)
+
+
+def _s(v) -> str:
+    """Safe string — handles NaN, None, trailing .0 on numeric IDs."""
+    if v is None or (isinstance(v, float) and v != v):
+        return ""
+    sv = str(v).strip()
+    if sv.endswith(".0") and sv[:-2].lstrip("-").isdigit():
+        sv = sv[:-2]
+    return sv
+
+
+def process_omop_bundle(input_file: str, output_file: str) -> None:
+    """
+    Read omop_{version}.xlsx (produced by omop_scraper.py) and write a
+    LinkML YAML schema to output_file.
+
+    All column headers are read dynamically from the sheet — no positions
+    or names hardcoded. Slot names follow the pattern {table}__{column}
+    (lower-snake-case) matching how phenx uses {protocol_id}_{var_name}.
+    """
+    # ── Columns sheet (one row = one CDE) ────────────────────────────────────
+    df = pd.read_excel(input_file, sheet_name="Columns (CDEs)", header=1)
+    df.columns = df.columns.str.strip()
+
+    # ── Tables sheet — for hierarchy fields not duplicated in Columns sheet ──
+    df_t = pd.read_excel(input_file, sheet_name="Tables", header=1)
+    df_t.columns = df_t.columns.str.strip()
+
+    # table_name → full row dict (all headers dynamic)
+    table_lookup: dict = {}
+    for _, row in df_t.iterrows():
+        tname = _s(row.get("Table Name", "")).upper()
+        if tname:
+            table_lookup[tname] = {k: _s(row.get(k, "")) for k in df_t.columns}
+
+    df = df[df["Column Name"].notna()].reset_index(drop=True)
+
+    # Resolve CDM version from README sheet
+    cdm_version = "unknown"
+    try:
+        df_readme = pd.read_excel(input_file, sheet_name="README", header=None)
+        for _, row in df_readme.iterrows():
+            if str(row.iloc[0]).strip().lower() == "cdm version":
+                m = re.search(r'(\d+\.\d+)', str(row.iloc[1]))
+                if m:
+                    cdm_version = m.group(1)
+                break
+    except Exception:
+        pass
+    if cdm_version == "unknown" and "CDM Version" in df.columns:
+        vals = df["CDM Version"].dropna().unique()
+        if len(vals):
+            cdm_version = _s(vals[0])
+
+    ver_slug = cdm_version.replace(".", "")
+    schema = {
+        "id":            f"https://example.org/schemas/omop_cdm_{ver_slug}_bundle",
+        "name":          "OMOPCDMBundleSchema",
+        "description": (
+            f"LinkML schema for OMOP CDM v{cdm_version} columns. "
+            "Generated from omop_{version}.xlsx by omop2linkml.py. "
+            "Hierarchy: TableGroup → Table → Column "
+            "(parallel to PhenX: Collection → SubCollection → Protocol → Variable)."
+        ),
+        "version":       f"{cdm_version}.0",
+        "default_range": "string",
+        "license":       "https://www.apache.org/licenses/LICENSE-2.0",
+        "imports":       ["linkml:types"],
+        "prefixes": {
+            "linkml": "https://w3id.org/linkml/",
+            "omop":   "https://ohdsi.github.io/CommonDataModel/",
+        },
+        "default_prefix": "omop",
+        "slots": {},
+    }
+
+    seen:    set = set()
+    skipped: int = 0
+
+    for _, row in df.iterrows():
+        col_id   = _s(row.get("Column ID (CDE ID)", ""))
+        col_name = _s(row.get("Column Name",         ""))
+        col_desc = _s(row.get("Column Description",  ""))
+        tname    = _s(row.get("Table Name",          "")).upper()
+
+        if not col_name or not tname:
+            skipped += 1
+            continue
+
+        # Slot name: {table_lower}__{column_lower}  e.g. person__birth_datetime
+        # Mirrors PhenX pattern where slot key is snake_case of the variable name
+        slot_key = f"{_to_snake(tname)}__{_to_snake(col_name)}"
+        if not slot_key or slot_key in seen:
+            skipped += 0 if slot_key in seen else 1
+            continue
+        seen.add(slot_key)
+
+        description = col_desc or col_name
+
+        # ── Annotations: one key per hierarchy level ──────────────────────────
+        # Mirrors phenx which has separate keys for protocol_id, protocol_name,
+        # domain_id, domain_name, sub_collection_id, collection_id, etc.
+        annotations: dict = {"source": "OMOP_CDM"}
+
+        # Column-level fields (from Columns sheet)
+        col_fields = {
+            "Column ID (CDE ID)": "source_variable_id",
+            "CDM Version":        "cdm_version",
+            "Column Name":        "column_name",
+            "Datatype":           "datatype",
+            "Is Required":        "is_required",
+            "Is Primary Key":     "is_primary_key",
+            "Is Foreign Key":     "is_foreign_key",
+            "FK Table":           "fk_table",
+            "FK Field":           "fk_field",
+            "FK Domain":          "fk_domain",
+            "FK Class":           "fk_class",
+        }
+        for sheet_col, annot_key in col_fields.items():
+            v = _s(row.get(sheet_col, ""))
+            if v:
+                annotations[annot_key] = v
+
+        # Table-level fields — prefer Columns sheet, fall back to Tables sheet
+        tbl_fields = {
+            "Table Name":        "table_name",
+            "Table Group":       "table_group",
+            "Schema":            "schema",
+            "Table URL":         "table_url",
+        }
+        for sheet_col, annot_key in tbl_fields.items():
+            v = _s(row.get(sheet_col, ""))
+            if not v and tname in table_lookup:
+                v = _s(table_lookup[tname].get(sheet_col, ""))
+            if v:
+                annotations[annot_key] = v
+
+        # Table description (truncated — long text, not needed for embedding)
+        td = _s(row.get("Table Description", ""))
+        if not td and tname in table_lookup:
+            td = _s(table_lookup[tname].get("Table Description", ""))
+        if td:
+            annotations["table_description"] = td[:300]
+
+        schema["slots"][slot_key] = {
+            "description": description,
+            "annotations": annotations,
+        }
+
+    os.makedirs(os.path.dirname(output_file) or ".", exist_ok=True)
+
+    raw = yaml.dump(schema, Dumper=_Dumper, sort_keys=False,
+                    default_flow_style=False, allow_unicode=True)
+    raw = raw.replace(": null\n", ":\n")
+
+    with open(output_file, "w", encoding="utf-8") as fh:
+        fh.write(raw)
+
+    print(f"OMOP CDM LinkML schema saved → {output_file} "
+          f"({len(schema['slots']):,} slots, {skipped} skipped, CDM v{cdm_version})")

--- a/cde2onto/README.md
+++ b/cde2onto/README.md
@@ -1,0 +1,126 @@
+# `cde2onto`: All-by-All Mappers
+
+> **Status:** early stage. This README covers just the two mapper scripts
+> below. A CLI wrapper and a full ontology-build README (covering the rest
+> of `cde2onto`) will be added later.
+
+These scripts inject OWL restrictions into an already-annotated CDE
+ontology, linking each CDE variable to the PhenX Bundle protocols or OMOP
+CDM columns it's semantically closest to. Matching is done via
+[`CurateGPT`](https://github.com/monarch-initiative/curategpt)'s
+`all-by-all` command against the `bundle_phenx` / `cdm_omop` ChromaDB
+collections built by `cde2vec`.
+
+| Script                    | Adds property   | Matches against  | ChromaDB collection |
+|---------------------------|-----------------|-------------------|----------------------|
+| `allxall_mapper_phenx.py` | `inBundleExact` / `inBundleClose` | PhenX protocols | `bundle_phenx` |
+| `allxall_mapper_omop.py`  | `inCDMExact` / `inCDMClose`       | OMOP CDM columns | `cdm_omop`     |
+
+### Thresholds
+
+| Property        | Similarity                  | phenx mapper | omop mapper |
+|------------------|------------------------------|--------------|-------------|
+| `*Exact`         | `>=` EXACT_THRESHOLD          | 0.98         | 0.97        |
+| `*Close`         | `>=` CLOSE_THRESHOLD, `<` EXACT | 0.90         | 0.85        |
+
+Thresholds are constants at the top of each script — edit `EXACT_THRESHOLD` /
+`CLOSE_THRESHOLD` directly if you need to tune them.
+
+---
+
+## Prerequisites
+
+- An **annotated OWL file** to inject into (`cdes_values_ontology_annotated.owl`) — produced by an earlier, not-yet-documented step in `cde2onto`.
+- A **populated ChromaDB** at `--chroma` containing:
+  - the source collection(s) you're matching against (e.g. `cde_phenx`, `cde_nih`)
+  - `bundle_phenx` and/or `cdm_omop`, built via `make embed-phenx-bundle` / `make embed-omop-cdm` (see the `cde2vec` README)
+- The corresponding LinkML schema file:
+  - `linkml/phenx_bundle_schema.yaml` for the PhenX mapper
+  - `linkml/omop_cdm_schema.yaml` (or `data/cdm-omop/omop_5.4.xlsx`) for the OMOP mapper
+
+---
+
+## Usage
+
+### PhenX Bundle mapper
+
+```bash
+python cde2onto/allxall_mapper_phenx.py \
+    --owl    cde2onto/cdes_values_ontology_annotated.owl \
+    --phenx  linkml/phenx_bundle_schema.yaml \
+    --chroma db \
+    --source cde_phenx \
+    --out    cde2onto/cdes_values_ontology_annotated_phenx.owl
+```
+
+### OMOP CDM mapper
+
+```bash
+python cde2onto/allxall_mapper_omop.py \
+    --owl    cde2onto/cdes_values_ontology_annotated_phenx.owl \
+    --omop   linkml/omop_cdm_schema.yaml \
+    --chroma db \
+    --source cde_phenx \
+    --out    cde2onto/cdes_values_ontology_annotated_phenx_omop.owl
+```
+
+### Chaining multiple sources
+
+Both scripts are incremental — pass the previous run's `--out` back in as
+the next run's `--owl`, and switch `--source` to the next collection
+(`cde_nih`, `cde_heal`, etc.). The PhenX/OMOP hierarchy and object
+properties are only appended once; re-runs detect them and skip.
+
+```bash
+python cde2onto/allxall_mapper_phenx.py --owl a.owl --phenx ... --source cde_phenx --out b.owl
+python cde2onto/allxall_mapper_phenx.py --owl b.owl --phenx ... --source cde_nih   --out c.owl
+python cde2onto/allxall_mapper_omop.py  --owl c.owl --omop  ... --source cde_phenx --out d.owl
+```
+
+---
+
+## Options
+
+| Flag                  | Applies to | Description                                                        |
+|------------------------|------------|----------------------------------------------------------------------|
+| `--owl`                | both       | Input annotated OWL file                                             |
+| `--phenx`              | phenx      | Path to `phenx_bundle_schema.yaml`                                   |
+| `--omop`               | omop       | Path to `omop_cdm_schema.yaml` or `omop_5.4.xlsx`                    |
+| `--chroma`             | both       | ChromaDB directory (e.g. `db`)                                       |
+| `--source`             | both       | Source collection to match against (e.g. `cde_phenx`, `cde_nih`)     |
+| `--out`                | both       | Output OWL file                                                      |
+| `--phenx-collection`   | phenx      | ChromaDB collection name for PhenX Bundle (default: `bundle_phenx`)  |
+| `--omop-collection`    | omop       | ChromaDB collection name for OMOP CDM (default: `cdm_omop`)          |
+| `--limit`              | both       | Max candidates per left item passed to `all-by-all -l` (default: 50) |
+| `--ns-prefix`          | both       | XML namespace prefix added to the OWL header (default: `ex`)         |
+
+---
+
+## Output
+
+Each run prints a summary of match counts and writes the modified OWL to
+`--out`, e.g.:
+
+```
+── Summary ──────────────────────────────────────────────────────────────
+  Input OWL      : cde2onto/cdes_values_ontology_annotated.owl
+  PhenX schema   : linkml/phenx_bundle_schema.yaml
+  ChromaDB       : db
+  Reference      : bundle_phenx
+  Source         : cde_phenx
+  OWL crosswalk  : 48,291 classes
+  Matched classes: 19,796
+  inBundleExact  : 5,011 protocol links  (>= 0.98)
+  inBundleClose  : 16,622 protocol links  (>= 0.9, < 0.98)
+  Output         : cde2onto/cdes_values_ontology_annotated_phenx_test.owl  (93.1 MB)
+─────────────────────────────────────────────────────────────────────────
+```
+
+---
+
+## Coming later
+
+- A CLI wrapper (`cde2onto` entry point) to replace the manual `python
+  cde2onto/allxall_mapper_*.py` invocations
+- A full README documenting the rest of the ontology-build pipeline
+  (annotation step, other mappers, final ontology assembly)

--- a/cde2onto/allxall_mapper_omop.py
+++ b/cde2onto/allxall_mapper_omop.py
@@ -1,0 +1,552 @@
+#!/usr/bin/env python3
+"""
+allxall_mapper_omop.py
+=======================
+Inject inCDMExact / inCDMClose OWL restrictions into an existing
+annotated CDE ontology by matching it against the cdm_omop ChromaDB
+collection via curategpt all-by-all.
+
+Thresholds
+----------
+  inCDMExact : similarity >= 0.99
+  inCDMClose : similarity >= 0.95 and < 0.99
+
+Architecture
+------------
+  INPUT : annotated OWL file (cdes_values_ontology_annotated.owl)
+          omop_cdm_schema.yaml (or omop_5.4.xlsx)
+          ChromaDB at --chroma
+  PROCESS:
+    1. Scan OWL -> build label_snake -> local_id map (crosswalk)
+    2. Run curategpt all-by-all -c cdm_omop -X <source> -t csv
+    3. Filter to SlotDefinition rows
+    4. right_name (source slot key) -> crosswalk -> OWL local_id
+    5. left_name  (cdm_omop slot key) -> omop_cdm_schema.yaml -> column_id/table
+    6. Inject owl:equivalentClass restriction into existing OWL class block
+    7. Append OMOP hierarchy + object properties (once, skipped on re-runs)
+  OUTPUT: same OWL with restrictions injected
+
+Usage
+-----
+  python cde2onto/allxall_mapper_omop.py \\
+      --owl    cde2onto/cdes_values_ontology_annotated_phenx.owl \\
+      --omop   linkml/omop_cdm_schema.yaml \\
+      --chroma db \\
+      --source cde_phenx \\
+      --out    cde2onto/cdes_values_ontology_annotated_phenx_omop.owl
+"""
+
+import argparse
+import csv
+import io
+import re
+import subprocess
+import unicodedata
+import uuid
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+
+EXACT_THRESHOLD = 0.97 #0.99
+CLOSE_THRESHOLD = 0.85 #0.95
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--owl",    required=True)
+    p.add_argument("--omop",   required=True,
+                   help="omop_cdm_schema.yaml or omop_5.4.xlsx")
+    p.add_argument("--chroma", required=True)
+    p.add_argument("--source", required=True,
+                   help="Source collection to match (e.g. cde_phenx, cde_nih)")
+    p.add_argument("--out",    required=True)
+    p.add_argument("--omop-collection", default="cdm_omop", dest="omop_collection")
+    p.add_argument("--limit",  type=int, default=50)
+    p.add_argument("--ns-prefix", default="ex", dest="ns_prefix")
+    return p.parse_args()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Utilities (shared with phenx mapper)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def safe_id(text):
+    text = unicodedata.normalize("NFKD", str(text))
+    text = re.sub(r"[^\w\s-]", "", text)
+    text = re.sub(r"[\s/,]+", "_", text.strip())
+    return text or "Unknown"
+
+def snake(text):
+    text = re.sub(r"[\s\-\.]+", "_", str(text).strip())
+    text = re.sub(r"[^a-zA-Z0-9_]", "", text)
+    text = re.sub(r"_+", "_", text).strip("_")
+    return text.lower()
+
+def xe(t):
+    return (t.replace("&", "&amp;").replace("<", "&lt;")
+             .replace(">", "&gt;").replace('"', "&quot;"))
+
+def _s(v):
+    return "" if (v is None or (isinstance(v, float) and v != v)) \
+           else str(v).strip()
+
+def fresh_node():
+    return "N" + uuid.uuid4().hex
+
+def owl_class(uri, label, comment, parent_uri):
+    return (
+        f'  <rdf:Description rdf:about="{uri}">\n'
+        f'    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>\n'
+        f'    <rdfs:label>{xe(label)}</rdfs:label>\n'
+        f'    <rdfs:comment>{xe(comment)}</rdfs:comment>\n'
+        f'    <rdfs:subClassOf rdf:resource="{parent_uri}"/>\n'
+        f'  </rdf:Description>\n'
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Step 1 — scan OWL (same as phenx mapper)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def scan_owl(owl_content):
+    ns_m = re.search(
+        r'rdf:about="(https?://[^"]+#)(?:cde_|dd_|bdc_|REPO_)', owl_content)
+    if not ns_m:
+        raise ValueError("Cannot detect OWL namespace")
+    ns = ns_m.group(1)
+
+    var_prefix = "cde_"
+    for pfx in ("cde_", "dd_", "bdc_"):
+        if re.search(r'rdf:about="' + re.escape(ns) + re.escape(pfx) + r'\d',
+                     owl_content):
+            var_prefix = pfx
+            break
+
+    block_pat = re.compile(
+        r'<rdf:Description rdf:about="' + re.escape(ns)
+        + re.escape(var_prefix) + r'[^"]+">.*?</rdf:Description>',
+        re.DOTALL)
+
+    label_to_lid: Dict[str, str] = {}
+    for m in block_pat.finditer(owl_content):
+        block = m.group(0)
+        lid_m = re.search(r'rdf:about="' + re.escape(ns) + r'([^"]+)"', block)
+        if not lid_m:
+            continue
+        local_id = lid_m.group(1)
+        labels = re.findall(r'<rdfs:label>(.*?)</rdfs:label>', block, re.DOTALL)
+        if labels:
+            label_to_lid[snake(labels[0].strip())] = local_id
+
+    return ns, var_prefix, label_to_lid
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Step 2 — run all-by-all (same as phenx mapper)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def run_all_by_all(chroma, left, right, limit):
+    cmd = [
+        "curategpt", "all-by-all",
+        "-p", chroma, "-c", left, "-X", right,
+        "-D", "chromadb",
+        "--threshold", str(CLOSE_THRESHOLD),
+        "-l", str(limit), "-t", "csv",
+    ]
+    print(f"    $ {' '.join(cmd)}")
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"    [ERROR] all-by-all failed:\n{result.stderr[-2000:]}")
+        return []
+    rows = list(csv.DictReader(io.StringIO(result.stdout)))
+    slot_rows = [r for r in rows if r.get("left_@type") == "SlotDefinition"]
+    print(f"    {len(slot_rows):,} SlotDefinition rows "
+          f"(of {len(rows):,} total)")
+    return slot_rows
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Step 3 — load OMOP schema
+# ─────────────────────────────────────────────────────────────────────────────
+
+def load_and_parse_omop(omop_path):
+    path = Path(omop_path)
+    if path.suffix.lower() in (".yaml", ".yml"):
+        import yaml
+        with open(path, encoding="utf-8") as f:
+            schema = yaml.safe_load(f)
+    elif path.suffix.lower() in (".xlsx", ".xls"):
+        schema = _xlsx_to_schema(str(path))
+    else:
+        raise ValueError(f"Unsupported --omop format: {path.suffix}")
+
+    table_groups: Dict[str, dict] = {}
+    tables:       Dict[str, dict] = {}
+    columns:      Dict[str, dict] = {}
+    slot_to_col:  Dict[str, str]  = {}
+
+    for slot_key, slot in schema.get("slots", {}).items():
+        ann     = slot.get("annotations", {})
+        col_id  = _s(ann.get("source_variable_id", slot_key))
+        tname   = _s(ann.get("table_name",  "")).upper()
+        tgroup  = _s(ann.get("table_group", "Unknown_Tables"))
+        tdesc   = _s(ann.get("table_description", ""))
+        turl    = _s(ann.get("table_url",   ""))
+        cdm_ver = _s(ann.get("cdm_version", ""))
+
+        if not tname:
+            continue
+
+        if tgroup not in table_groups:
+            table_groups[tgroup] = {"tables": []}
+        if tname not in table_groups[tgroup]["tables"]:
+            table_groups[tgroup]["tables"].append(tname)
+
+        if tname not in tables:
+            tables[tname] = {"group": tgroup, "description": tdesc,
+                              "url": turl, "cdm_version": cdm_ver}
+
+        if col_id and col_id not in columns:
+            columns[col_id] = {
+                "name":        _s(ann.get("column_name",   slot_key)),
+                "description": _s(slot.get("description",  "")),
+                "table_name":  tname,
+                "datatype":    _s(ann.get("datatype",      "")),
+                "is_required": _s(ann.get("is_required",   "")),
+                "is_pk":       _s(ann.get("is_primary_key","")),
+            }
+            slot_to_col[slot_key] = col_id
+
+    cdm_ver = (list(tables.values())[0].get("cdm_version", "") if tables else "")
+    print(f"    CDM v{cdm_ver}  |  {len(table_groups)} groups  "
+          f"{len(tables)} tables  {len(columns)} columns  "
+          f"{len(slot_to_col):,} slot->column mappings")
+    return table_groups, tables, columns, slot_to_col
+
+
+def _xlsx_to_schema(xlsx_path):
+    import pandas as pd
+    df = pd.read_excel(xlsx_path, sheet_name="Columns (CDEs)", header=1)
+    df.columns = df.columns.str.strip()
+
+    COL_MAP = {
+        "Column ID (CDE ID)": "source_variable_id",
+        "CDM Version":        "cdm_version",
+        "Column Name":        "column_name",
+        "Datatype":           "datatype",
+        "Is Required":        "is_required",
+        "Is Primary Key":     "is_primary_key",
+        "Table Name":         "table_name",
+        "Table Description":  "table_description",
+        "Table Group":        "table_group",
+        "Table URL":          "table_url",
+    }
+    active = {c: k for c, k in COL_MAP.items() if c in df.columns}
+
+    def _snk(t):
+        t = re.sub(r'[\s\-\.]+', '_', str(t).strip())
+        t = re.sub(r'[^a-zA-Z0-9_]', '', t)
+        return re.sub(r'_+', '_', t).strip('_').lower()
+
+    slots = {}
+    for _, row in df.iterrows():
+        col_name = _s(row.get("Column Name", ""))
+        tname    = _s(row.get("Table Name",  "")).upper()
+        desc     = _s(row.get("Column Description", col_name))
+        if not col_name or not tname:
+            continue
+        key = f"{_snk(tname)}__{_snk(col_name)}"
+        if not key or key in slots:
+            continue
+        ann = {"source": "OMOP_CDM"}
+        for col, ak in active.items():
+            v = _s(row.get(col, ""))
+            if v:
+                ann[ak] = v
+        slots[key] = {"description": desc, "annotations": ann}
+
+    return {"slots": slots}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Step 4 — build match_results
+# ─────────────────────────────────────────────────────────────────────────────
+
+def build_match_results(rows, label_to_lid, slot_to_col, columns):
+    results: Dict[str, dict] = {}
+    no_crosswalk = 0
+    no_col       = 0
+
+    for row in rows:
+        left_name  = _s(row.get("left_name",  ""))
+        right_name = _s(row.get("right_name", ""))
+        try:
+            score = float(row.get("similarity", 0))
+        except (TypeError, ValueError):
+            continue
+
+        local_id = label_to_lid.get(right_name)
+        if not local_id:
+            no_crosswalk += 1
+            continue
+
+        col_id = slot_to_col.get(left_name)
+        if not col_id or col_id not in columns:
+            no_col += 1
+            continue
+
+        if local_id not in results:
+            results[local_id] = {"exact": [], "close": []}
+
+        bucket = "exact" if score >= EXACT_THRESHOLD else "close"
+        if col_id not in results[local_id][bucket]:
+            results[local_id][bucket].append(col_id)
+
+    n_exact = sum(1 for v in results.values() if v["exact"])
+    n_close = sum(1 for v in results.values() if v["close"])
+    print(f"    Matched {len(results):,} OWL classes "
+          f"({n_exact:,} inCDMExact, {n_close:,} inCDMClose)")
+    if no_crosswalk:
+        print(f"    [INFO] {no_crosswalk:,} rows had no OWL crosswalk")
+    if no_col:
+        print(f"    [INFO] {no_col:,} rows had no column mapping in schema")
+    return results
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Step 5 — inject restrictions (same pattern as phenx mapper)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def build_rdf_list(uris):
+    nodes = [fresh_node() for _ in uris]
+    blocks = []
+    for i, (uri, nid) in enumerate(zip(uris, nodes)):
+        rest = (
+            'rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"'
+            if i == len(uris) - 1 else f'rdf:nodeID="{nodes[i+1]}"'
+        )
+        blocks.append(
+            f'  <rdf:Description rdf:nodeID="{nid}">\n'
+            f'    <rdf:first rdf:resource="{uri}"/>\n'
+            f'    <rdf:rest {rest}/>\n'
+            f'  </rdf:Description>\n'
+        )
+    return "".join(blocks), nodes[0]
+
+
+def build_restriction(prop_uri, target_uris):
+    restr_id = fresh_node()
+    if len(target_uris) == 1:
+        blocks = (
+            f'  <rdf:Description rdf:nodeID="{restr_id}">\n'
+            f'    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>\n'
+            f'    <owl:onProperty rdf:resource="{prop_uri}"/>\n'
+            f'    <owl:someValuesFrom rdf:resource="{target_uris[0]}"/>\n'
+            f'  </rdf:Description>\n'
+        )
+    else:
+        list_xml, list_head = build_rdf_list(target_uris)
+        union_id = fresh_node()
+        blocks = (
+            f'  <rdf:Description rdf:nodeID="{restr_id}">\n'
+            f'    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>\n'
+            f'    <owl:onProperty rdf:resource="{prop_uri}"/>\n'
+            f'    <owl:someValuesFrom rdf:nodeID="{union_id}"/>\n'
+            f'  </rdf:Description>\n'
+            f'  <rdf:Description rdf:nodeID="{union_id}">\n'
+            f'    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>\n'
+            f'    <owl:unionOf rdf:nodeID="{list_head}"/>\n'
+            f'  </rdf:Description>\n'
+            + list_xml
+        )
+    return blocks, restr_id
+
+
+def col_uri(col_id, ns):
+    return f"{ns}{safe_id(col_id)}"
+
+
+def inject_restrictions(owl_content, match_results, columns, var_prefix, ns):
+    blank_nodes: List[str] = []
+
+    def make_equiv(prop_local, ids, uri_fn):
+        uris     = [uri_fn(i, ns) for i in ids]
+        xml, rid = build_restriction(f"{ns}{prop_local}", uris)
+        blank_nodes.append(xml)
+        return f'    <owl:equivalentClass rdf:nodeID="{rid}"/>\n'
+
+    pat = re.compile(
+        r'(<rdf:Description rdf:about="' + re.escape(ns)
+        + re.escape(var_prefix) + r'[^"]+">)(.*?)(</rdf:Description>)',
+        re.DOTALL)
+
+    def replacer(m):
+        open_tag, body, close_tag = m.group(1), m.group(2), m.group(3)
+        lid_m = re.search(r'rdf:about="' + re.escape(ns) + r'([^"]+)"', open_tag)
+        if not lid_m:
+            return m.group(0)
+        mr = match_results.get(lid_m.group(1))
+        if not mr:
+            return m.group(0)
+        injected = ""
+        if mr.get("exact"):
+            injected += make_equiv("inCDMExact", mr["exact"], col_uri)
+        if mr.get("close"):
+            injected += make_equiv("inCDMClose", mr["close"], col_uri)
+        return open_tag + body + injected + close_tag
+
+    return pat.sub(replacer, owl_content), "".join(blank_nodes)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Step 6 — append OMOP hierarchy + object properties (once)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def build_property_owl(ns):
+    props = [
+        ("inCDMExact",
+         f"Links a CDE variable to OMOP CDM Column(s) with cosine similarity "
+         f">= {EXACT_THRESHOLD}."),
+        ("inCDMClose",
+         f"Links a CDE variable to OMOP CDM Column(s) with cosine similarity "
+         f">= {CLOSE_THRESHOLD} and < {EXACT_THRESHOLD}."),
+    ]
+    parts = ['\n  <!-- OMOP CDM Object Properties -->\n\n']
+    for local, comment in props:
+        parts.append(
+            f'  <rdf:Description rdf:about="{ns}{local}">\n'
+            f'    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>\n'
+            f'    <rdfs:label>{xe(local)}</rdfs:label>\n'
+            f'    <rdfs:comment>{xe(comment)}</rdfs:comment>\n'
+            f'  </rdf:Description>\n\n'
+        )
+    return "".join(parts)
+
+
+def build_hierarchy_owl(table_groups, tables, columns, ns):
+    parts = ['\n  <!-- OMOP CDM Hierarchy -->\n\n']
+
+    parts.append(
+        f'  <rdf:Description rdf:about="{ns}CDM_Bundles">\n'
+        f'    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>\n'
+        f'    <rdfs:label>CDM_Bundles</rdfs:label>\n'
+        f'    <rdfs:comment>Top-level class for all CDM bundle types.</rdfs:comment>\n'
+        f'  </rdf:Description>\n\n'
+        f'  <rdf:Description rdf:about="{ns}cdm_omop">\n'
+        f'    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>\n'
+        f'    <rdfs:label>cdm_omop</rdfs:label>\n'
+        f'    <rdfs:comment>OMOP Common Data Model. '
+        f'{len(table_groups)} table groups, {len(tables)} tables, '
+        f'{len(columns)} columns.</rdfs:comment>\n'
+        f'    <rdfs:subClassOf rdf:resource="{ns}CDM_Bundles"/>\n'
+        f'  </rdf:Description>\n\n'
+    )
+
+    for grp in sorted(table_groups):
+        local = f"OMOPTableGroup_{safe_id(grp)}"
+        parts.append(owl_class(
+            f"{ns}{local}", grp.replace("_", " "),
+            f"OMOP CDM table group: {grp}.", f"{ns}cdm_omop"))
+
+    for tname, tinfo in sorted(tables.items()):
+        grp_local = f"OMOPTableGroup_{safe_id(tinfo['group'])}"
+        desc = tinfo["description"][:300] if tinfo["description"] else tname
+        url  = f"  URL: {tinfo['url']}" if tinfo["url"] else ""
+        parts.append(owl_class(
+            f"{ns}OMOPTable_{safe_id(tname)}", tname,
+            f"{desc}{url}", f"{ns}{grp_local}"))
+
+    for col_id, col in sorted(columns.items(),
+                               key=lambda x: (x[1]["table_name"], x[0])):
+        meta = []
+        if col["datatype"]:    meta.append(f"Datatype: {col['datatype']}.")
+        if col["is_required"] == "Yes": meta.append("Required.")
+        if col["is_pk"]       == "Yes": meta.append("Primary key.")
+        desc    = col["description"][:400] if col["description"] else col["name"]
+        comment = (desc + ("  " + "  ".join(meta) if meta else "")).strip()
+        parts.append(owl_class(
+            col_uri(col_id, ns),
+            f"{col['table_name']}.{col['name']}",
+            comment,
+            f"{ns}OMOPTable_{safe_id(col['table_name'])}"))
+
+    return "".join(parts)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Main
+# ─────────────────────────────────────────────────────────────────────────────
+
+def main():
+    args = parse_args()
+
+    print("[1] Loading OWL …")
+    owl_content = Path(args.owl).read_text(encoding="utf-8")
+    ns, var_prefix, label_to_lid = scan_owl(owl_content)
+    print(f"    Namespace  : {ns}")
+    print(f"    Var prefix : {var_prefix}")
+    print(f"    Crosswalk  : {len(label_to_lid):,} OWL classes")
+
+    print(f"\n[2] Running all-by-all: "
+          f"'{args.omop_collection}' vs '{args.source}' …")
+    rows = run_all_by_all(
+        args.chroma, args.omop_collection, args.source, args.limit)
+
+    print(f"\n[3] Loading {args.omop} …")
+    table_groups, tables, columns, slot_to_col = load_and_parse_omop(args.omop)
+
+    print(f"\n[4] Building match_results …")
+    print(f"    inCDMExact : similarity >= {EXACT_THRESHOLD}")
+    print(f"    inCDMClose : similarity >= {CLOSE_THRESHOLD} "
+          f"and < {EXACT_THRESHOLD}")
+    match_results = build_match_results(
+        rows, label_to_lid, slot_to_col, columns)
+
+    print(f"\n[5] Injecting owl:equivalentClass restrictions …")
+    out, blank_nodes = inject_restrictions(
+        owl_content, match_results, columns, var_prefix, ns)
+
+    already_props = f"{ns}inCDMExact"  in owl_content
+    already_hier  = f"{ns}cdm_omop"    in owl_content
+    if already_props:
+        print(f"    [SKIP] Properties already present (incremental run)")
+    if already_hier:
+        print(f"    [SKIP] OMOP hierarchy already present (incremental run)")
+
+    prop_owl = "" if already_props else build_property_owl(ns)
+    hier_owl = "" if already_hier  else build_hierarchy_owl(
+        table_groups, tables, columns, ns)
+
+    if f'xmlns:{args.ns_prefix}=' not in out:
+        out = out.replace('<rdf:RDF',
+                          f'<rdf:RDF\n   xmlns:{args.ns_prefix}="{ns}"', 1)
+
+    out = out.replace(
+        "</rdf:RDF>",
+        blank_nodes + prop_owl + hier_owl + "\n</rdf:RDF>",
+    )
+
+    print(f"\n[6] Writing → {args.out}")
+    Path(args.out).write_text(out, encoding="utf-8")
+    size_mb = Path(args.out).stat().st_size / 1024 / 1024
+
+    n_exact = sum(len(v["exact"]) for v in match_results.values())
+    n_close = sum(len(v["close"]) for v in match_results.values())
+    print(f"""
+── Summary ──────────────────────────────────────────────────────────────
+  Input OWL      : {args.owl}
+  OMOP schema    : {args.omop}
+  ChromaDB       : {args.chroma}
+  Reference      : {args.omop_collection}
+  Source         : {args.source}
+  OWL crosswalk  : {len(label_to_lid):,} classes
+  Matched classes: {len(match_results):,}
+  inCDMExact     : {n_exact:,} column links  (>= {EXACT_THRESHOLD})
+  inCDMClose     : {n_close:,} column links  (>= {CLOSE_THRESHOLD}, < {EXACT_THRESHOLD})
+  Output         : {args.out}  ({size_mb:.1f} MB)
+─────────────────────────────────────────────────────────────────────────""")
+
+
+if __name__ == "__main__":
+    main()

--- a/cde2onto/allxall_mapper_phenx.py
+++ b/cde2onto/allxall_mapper_phenx.py
@@ -1,0 +1,569 @@
+#!/usr/bin/env python3
+"""
+allxall_mapper_phenx.py
+========================
+Inject inBundleExact / inBundleClose OWL restrictions into an existing
+annotated CDE ontology by matching it against the bundle_phenx ChromaDB
+collection via curategpt all-by-all.
+
+Thresholds
+----------
+  inBundleExact : similarity >= 0.99
+  inBundleClose : similarity >= 0.95 and < 0.99
+
+Architecture
+------------
+  INPUT : annotated OWL file (cdes_values_ontology_annotated.owl)
+          phenx_bundle_schema.yaml
+          ChromaDB at --chroma
+  PROCESS:
+    1. Scan OWL → build label_snake -> local_id map (crosswalk)
+    2. Run curategpt all-by-all -c bundle_phenx -X <source> -t csv
+    3. Filter to SlotDefinition rows
+    4. right_name (cde_phenx slot key) -> crosswalk -> OWL local_id
+    5. left_name  (bundle_phenx slot key) -> phenx_bundle_schema.yaml -> protocol_id
+    6. Inject owl:equivalentClass restriction into existing OWL class block
+    7. Append PhenX hierarchy + object properties (once, skipped on re-runs)
+  OUTPUT: same OWL with restrictions injected
+
+Usage
+-----
+  # First source
+  python cde2onto/allxall_mapper_phenx.py \\
+      --owl    cde2onto/cdes_values_ontology_annotated.owl \\
+      --phenx  linkml/phenx_bundle_schema.yaml \\
+      --chroma db \\
+      --source cde_phenx \\
+      --out    cde2onto/cdes_values_ontology_annotated_phenx.owl
+
+  # Incremental: chain sources
+  python cde2onto/allxall_mapper_phenx.py \\
+      --owl    cde2onto/cdes_values_ontology_annotated_phenx.owl \\
+      --phenx  linkml/phenx_bundle_schema.yaml \\
+      --chroma db \\
+      --source cde_nih \\
+      --out    cde2onto/cdes_values_ontology_annotated_phenx2.owl
+"""
+
+import argparse
+import csv
+import io
+import re
+import subprocess
+import unicodedata
+import uuid
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Constants
+# ─────────────────────────────────────────────────────────────────────────────
+
+EXACT_THRESHOLD = 0.98 #0.99
+CLOSE_THRESHOLD = 0.90 #0.95
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# CLI
+# ─────────────────────────────────────────────────────────────────────────────
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--owl",    required=True, help="Input annotated OWL file")
+    p.add_argument("--phenx",  required=True, help="phenx_bundle_schema.yaml")
+    p.add_argument("--chroma", required=True, help="ChromaDB directory (e.g. db)")
+    p.add_argument("--source", required=True,
+                   help="Source collection to match (e.g. cde_phenx, cde_nih)")
+    p.add_argument("--out",    required=True, help="Output OWL file")
+    p.add_argument("--phenx-collection", default="bundle_phenx",
+                   dest="phenx_collection")
+    p.add_argument("--limit", type=int, default=50,
+                   help="all-by-all -l flag: candidates per left item (default 50)")
+    p.add_argument("--ns-prefix", default="ex", dest="ns_prefix")
+    return p.parse_args()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Utilities
+# ─────────────────────────────────────────────────────────────────────────────
+
+def safe_id(text: str) -> str:
+    text = unicodedata.normalize("NFKD", str(text))
+    text = re.sub(r"[^\w\s-]", "", text)
+    text = re.sub(r"[\s/,]+", "_", text.strip())
+    return text or "Unknown"
+
+def snake(text: str) -> str:
+    """Convert OWL rdfs:label to the slot-key format used in ChromaDB.
+    PX121802_Anxiety_Disorders -> px121802_anxiety_disorders"""
+    text = re.sub(r"[\s\-\.]+", "_", str(text).strip())
+    text = re.sub(r"[^a-zA-Z0-9_]", "", text)
+    text = re.sub(r"_+", "_", text).strip("_")
+    return text.lower()
+
+def xe(t: str) -> str:
+    return (t.replace("&", "&amp;").replace("<", "&lt;")
+             .replace(">", "&gt;").replace('"', "&quot;"))
+
+def _s(v) -> str:
+    return "" if (v is None or (isinstance(v, float) and v != v)) \
+           else str(v).strip()
+
+def fresh_node() -> str:
+    return "N" + uuid.uuid4().hex
+
+def owl_class(uri, label, comment, parent_uri):
+    return (
+        f'  <rdf:Description rdf:about="{uri}">\n'
+        f'    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>\n'
+        f'    <rdfs:label>{xe(label)}</rdfs:label>\n'
+        f'    <rdfs:comment>{xe(comment)}</rdfs:comment>\n'
+        f'    <rdfs:subClassOf rdf:resource="{parent_uri}"/>\n'
+        f'  </rdf:Description>\n'
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Step 1 — scan OWL → {snake(label): local_id}  crosswalk
+# ─────────────────────────────────────────────────────────────────────────────
+
+def scan_owl(owl_content: str) -> Tuple[str, str, Dict[str, str]]:
+    """
+    Returns (namespace, var_prefix, label_to_local_id).
+    label_to_local_id: { snake(rdfs:label): local_id }
+    Used to map all-by-all right_name -> OWL local_id.
+    """
+    ns_m = re.search(
+        r'rdf:about="(https?://[^"]+#)(?:cde_|dd_|bdc_|REPO_)', owl_content)
+    if not ns_m:
+        raise ValueError("Cannot detect OWL namespace")
+    ns = ns_m.group(1)
+
+    var_prefix = "cde_"
+    for pfx in ("cde_", "dd_", "bdc_"):
+        if re.search(r'rdf:about="' + re.escape(ns) + re.escape(pfx) + r'\d',
+                     owl_content):
+            var_prefix = pfx
+            break
+
+    block_pat = re.compile(
+        r'<rdf:Description rdf:about="' + re.escape(ns)
+        + re.escape(var_prefix) + r'[^"]+">.*?</rdf:Description>',
+        re.DOTALL)
+
+    label_to_lid: Dict[str, str] = {}
+    for m in block_pat.finditer(owl_content):
+        block = m.group(0)
+        lid_m = re.search(r'rdf:about="' + re.escape(ns) + r'([^"]+)"', block)
+        if not lid_m:
+            continue
+        local_id = lid_m.group(1)
+        labels = re.findall(r'<rdfs:label>(.*?)</rdfs:label>', block, re.DOTALL)
+        if labels:
+            key = snake(labels[0].strip())
+            label_to_lid[key] = local_id
+
+    return ns, var_prefix, label_to_lid
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Step 2 — run curategpt all-by-all
+# ─────────────────────────────────────────────────────────────────────────────
+
+def run_all_by_all(chroma: str, left: str, right: str,
+                   limit: int) -> List[Dict[str, str]]:
+    """Run at the close threshold (0.95) — we split exact/close ourselves."""
+    cmd = [
+        "curategpt", "all-by-all",
+        "-p", chroma,
+        "-c", left,
+        "-X", right,
+        "-D", "chromadb",
+        "--threshold", str(CLOSE_THRESHOLD),
+        "-l", str(limit),
+        "-t", "csv",
+    ]
+    print(f"    $ {' '.join(cmd)}")
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"    [ERROR] all-by-all failed:\n{result.stderr[-2000:]}")
+        return []
+    rows = list(csv.DictReader(io.StringIO(result.stdout)))
+    slot_rows = [r for r in rows if r.get("left_@type") == "SlotDefinition"]
+    print(f"    {len(slot_rows):,} SlotDefinition rows "
+          f"(of {len(rows):,} total, {len(rows)-len(slot_rows):,} noise filtered)")
+    return slot_rows
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Step 3 — load PhenX schema → slot_to_proto + hierarchy
+# ─────────────────────────────────────────────────────────────────────────────
+
+def load_and_parse_phenx(yaml_path: str):
+    import yaml
+    with open(yaml_path, encoding="utf-8") as f:
+        schema = yaml.safe_load(f)
+
+    collections:   Dict[str, dict] = {}
+    subcols:       Dict[str, dict] = {}
+    domains:       Dict[str, dict] = {}
+    proto_info:    Dict[str, dict] = {}
+    slot_to_proto: Dict[str, str]  = {}
+
+    for slot_key, slot in schema.get("slots", {}).items():
+        ann    = slot.get("annotations", {})
+        pid    = _s(ann.get("protocol_id",         ""))
+        pname  = _s(ann.get("protocol_name",       ""))
+        purl   = _s(ann.get("protocol_url",        ""))
+        did    = _s(ann.get("domain_id",           ""))
+        dname  = _s(ann.get("domain_name",         ""))
+        sub_id = _s(ann.get("sub_collection_id",   ""))
+        sub_nm = _s(ann.get("sub_collection_name", ""))
+        col_id = _s(ann.get("collection_id",       ""))
+        col_nm = _s(ann.get("collection_name",     ""))
+
+        if not pid:
+            continue
+
+        if col_id and col_id not in collections:
+            collections[col_id] = {"name": col_nm}
+        if sub_id and sub_id not in subcols:
+            subcols[sub_id] = {"name": sub_nm, "col_id": col_id}
+        if did and did not in domains:
+            domains[did] = {"name": dname, "col_id": col_id, "sub_id": sub_id}
+        if pid not in proto_info:
+            proto_info[pid] = {"name": pname, "url": purl,
+                               "domain_id": did, "sub_id": sub_id, "col_id": col_id}
+        slot_to_proto[slot_key] = pid
+
+    print(f"    {len(collections)} collections  {len(subcols)} sub-collections  "
+          f"{len(domains)} domains  {len(proto_info)} protocols  "
+          f"{len(slot_to_proto):,} slot->protocol mappings")
+    return collections, subcols, domains, proto_info, slot_to_proto
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Step 4 — build match_results
+# { owl_local_id: { 'exact': [proto_id,...], 'close': [proto_id,...] } }
+# ─────────────────────────────────────────────────────────────────────────────
+
+def build_match_results(
+        rows: List[Dict[str, str]],
+        label_to_lid: Dict[str, str],
+        slot_to_proto: Dict[str, str],
+        proto_info: Dict,
+) -> Dict[str, dict]:
+    results: Dict[str, dict] = {}
+    no_crosswalk = 0
+    no_proto     = 0
+
+    for row in rows:
+        left_name  = _s(row.get("left_name",  ""))
+        right_name = _s(row.get("right_name", ""))
+        try:
+            score = float(row.get("similarity", 0))
+        except (TypeError, ValueError):
+            continue
+
+        # Crosswalk: right_name (ChromaDB slot key) -> OWL local_id
+        local_id = label_to_lid.get(right_name)
+        if not local_id:
+            no_crosswalk += 1
+            continue
+
+        # left_name (bundle_phenx slot key) -> protocol_id
+        pid = slot_to_proto.get(left_name)
+        if not pid or pid not in proto_info:
+            no_proto += 1
+            continue
+
+        if local_id not in results:
+            results[local_id] = {"exact": [], "close": []}
+
+        if score >= EXACT_THRESHOLD:
+            if pid not in results[local_id]["exact"]:
+                results[local_id]["exact"].append(pid)
+        else:  # already filtered to >= CLOSE_THRESHOLD
+            if pid not in results[local_id]["close"]:
+                results[local_id]["close"].append(pid)
+
+    n_exact = sum(1 for v in results.values() if v["exact"])
+    n_close = sum(1 for v in results.values() if v["close"])
+    print(f"    Matched {len(results):,} OWL classes "
+          f"({n_exact:,} inBundleExact, {n_close:,} inBundleClose)")
+    if no_crosswalk:
+        print(f"    [INFO] {no_crosswalk:,} rows had no OWL crosswalk "
+              f"(source slot key not found via snake(label))")
+    if no_proto:
+        print(f"    [INFO] {no_proto:,} rows had no protocol mapping in schema")
+    return results
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Step 5 — inject owl:equivalentClass restrictions into existing OWL classes
+# ─────────────────────────────────────────────────────────────────────────────
+
+def build_rdf_list(uris: List[str]) -> Tuple[str, str]:
+    nodes = [fresh_node() for _ in uris]
+    blocks = []
+    for i, (uri, nid) in enumerate(zip(uris, nodes)):
+        rest = (
+            'rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"'
+            if i == len(uris) - 1 else f'rdf:nodeID="{nodes[i+1]}"'
+        )
+        blocks.append(
+            f'  <rdf:Description rdf:nodeID="{nid}">\n'
+            f'    <rdf:first rdf:resource="{uri}"/>\n'
+            f'    <rdf:rest {rest}/>\n'
+            f'  </rdf:Description>\n'
+        )
+    return "".join(blocks), nodes[0]
+
+
+def build_restriction(prop_uri: str, target_uris: List[str]) -> Tuple[str, str]:
+    restr_id = fresh_node()
+    if len(target_uris) == 1:
+        blocks = (
+            f'  <rdf:Description rdf:nodeID="{restr_id}">\n'
+            f'    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>\n'
+            f'    <owl:onProperty rdf:resource="{prop_uri}"/>\n'
+            f'    <owl:someValuesFrom rdf:resource="{target_uris[0]}"/>\n'
+            f'  </rdf:Description>\n'
+        )
+    else:
+        list_xml, list_head = build_rdf_list(target_uris)
+        union_id = fresh_node()
+        blocks = (
+            f'  <rdf:Description rdf:nodeID="{restr_id}">\n'
+            f'    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>\n'
+            f'    <owl:onProperty rdf:resource="{prop_uri}"/>\n'
+            f'    <owl:someValuesFrom rdf:nodeID="{union_id}"/>\n'
+            f'  </rdf:Description>\n'
+            f'  <rdf:Description rdf:nodeID="{union_id}">\n'
+            f'    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>\n'
+            f'    <owl:unionOf rdf:nodeID="{list_head}"/>\n'
+            f'  </rdf:Description>\n'
+            + list_xml
+        )
+    return blocks, restr_id
+
+
+def proto_uri(pid: str, proto_info: Dict, ns: str) -> str:
+    name = safe_id(proto_info[pid]["name"]) if pid in proto_info else safe_id(pid)
+    return f"{ns}PhenXProtocol_{pid}_{name}"
+
+
+def inject_restrictions(
+        owl_content: str,
+        match_results: Dict[str, dict],
+        proto_info: Dict,
+        var_prefix: str,
+        ns: str,
+) -> Tuple[str, str]:
+    """
+    Inject owl:equivalentClass restrictions into existing OWL class blocks.
+    Returns (modified_owl, blank_node_xml).
+    """
+    blank_nodes: List[str] = []
+
+    def make_equiv(prop_local: str, pids: List[str]) -> str:
+        prop_uri_  = f"{ns}{prop_local}"
+        uris       = [proto_uri(p, proto_info, ns) for p in pids]
+        xml, rid   = build_restriction(prop_uri_, uris)
+        blank_nodes.append(xml)
+        return f'    <owl:equivalentClass rdf:nodeID="{rid}"/>\n'
+
+    pat = re.compile(
+        r'(<rdf:Description rdf:about="' + re.escape(ns)
+        + re.escape(var_prefix) + r'[^"]+">)(.*?)(</rdf:Description>)',
+        re.DOTALL)
+
+    def replacer(m: re.Match) -> str:
+        open_tag, body, close_tag = m.group(1), m.group(2), m.group(3)
+        lid_m = re.search(r'rdf:about="' + re.escape(ns) + r'([^"]+)"', open_tag)
+        if not lid_m:
+            return m.group(0)
+        mr = match_results.get(lid_m.group(1))
+        if not mr:
+            return m.group(0)
+        injected = ""
+        if mr.get("exact"):
+            injected += make_equiv("inBundleExact", mr["exact"])
+        if mr.get("close"):
+            injected += make_equiv("inBundleClose", mr["close"])
+        return open_tag + body + injected + close_tag
+
+    modified = pat.sub(replacer, owl_content)
+    return modified, "".join(blank_nodes)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Step 6 — append PhenX hierarchy + object properties (once)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def build_property_owl(ns: str) -> str:
+    props = [
+        ("inBundleExact",
+         f"Links a CDE variable to PhenX Protocol(s) with cosine similarity "
+         f">= {EXACT_THRESHOLD}."),
+        ("inBundleClose",
+         f"Links a CDE variable to PhenX Protocol(s) with cosine similarity "
+         f">= {CLOSE_THRESHOLD} and < {EXACT_THRESHOLD}."),
+    ]
+    parts = ['\n  <!-- PhenX Bundle Object Properties -->\n\n']
+    for local, comment in props:
+        parts.append(
+            f'  <rdf:Description rdf:about="{ns}{local}">\n'
+            f'    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>\n'
+            f'    <rdfs:label>{xe(local)}</rdfs:label>\n'
+            f'    <rdfs:comment>{xe(comment)}</rdfs:comment>\n'
+            f'  </rdf:Description>\n\n'
+        )
+    return "".join(parts)
+
+
+def build_hierarchy_owl(collections, subcols, domains, proto_info, ns) -> str:
+    dom_pfx = "PhenXDomain_"
+    parts   = ['\n  <!-- PhenX Bundle Hierarchy -->\n\n']
+
+    parts.append(
+        f'  <rdf:Description rdf:about="{ns}Bundles">\n'
+        f'    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>\n'
+        f'    <rdfs:label>Bundles</rdfs:label>\n'
+        f'    <rdfs:comment>Top-level class for all bundle types.</rdfs:comment>\n'
+        f'  </rdf:Description>\n\n'
+        f'  <rdf:Description rdf:about="{ns}bundle_phenx">\n'
+        f'    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>\n'
+        f'    <rdfs:label>bundle_phenx</rdfs:label>\n'
+        f'    <rdfs:comment>PhenX Toolkit bundle.</rdfs:comment>\n'
+        f'    <rdfs:subClassOf rdf:resource="{ns}Bundles"/>\n'
+        f'  </rdf:Description>\n\n'
+    )
+
+    for col_id, col in sorted(collections.items(), key=lambda x: x[1]["name"]):
+        local = f"PhenXCollection_{safe_id(col['name'])}"
+        parts.append(owl_class(f"{ns}{local}", col["name"],
+                               f"PhenX Collection (ID {col_id}).",
+                               f"{ns}bundle_phenx"))
+
+    for sub_id, sub in sorted(subcols.items(), key=lambda x: x[1]["name"]):
+        col    = collections.get(sub.get("col_id", ""), {})
+        parent = (f"PhenXCollection_{safe_id(col['name'])}"
+                  if col else "bundle_phenx")
+        parts.append(owl_class(f"{ns}PhenXSubCollection_{safe_id(sub['name'])}",
+                               sub["name"],
+                               f"PhenX Sub-collection (ID {sub_id}).",
+                               f"{ns}{parent}"))
+
+    for dom_id, dom in sorted(domains.items(), key=lambda x: x[1]["name"]):
+        sub    = subcols.get(dom.get("sub_id", ""), {})
+        parent = (f"PhenXSubCollection_{safe_id(sub['name'])}"
+                  if sub else "bundle_phenx")
+        parts.append(owl_class(f"{ns}{dom_pfx}{safe_id(dom['name'])}",
+                               dom["name"],
+                               f"PhenX Domain (ID {dom_id}).",
+                               f"{ns}{parent}"))
+
+    for pid, proto in sorted(proto_info.items(), key=lambda x: x[1]["name"]):
+        dom    = domains.get(proto.get("domain_id", ""), {})
+        sub    = subcols.get(proto.get("sub_id", ""), {})
+        parent = (f"{dom_pfx}{safe_id(dom['name'])}" if dom else
+                  f"PhenXSubCollection_{safe_id(sub['name'])}" if sub else
+                  "bundle_phenx")
+        parts.append(owl_class(
+            proto_uri(pid, proto_info, ns),
+            proto["name"],
+            f"PhenX Protocol {pid}. URL: {proto['url']}",
+            f"{ns}{parent}",
+        ))
+
+    return "".join(parts)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Main
+# ─────────────────────────────────────────────────────────────────────────────
+
+def main():
+    args = parse_args()
+
+    # 1. Load OWL + build crosswalk
+    print("[1] Loading OWL …")
+    owl_content = Path(args.owl).read_text(encoding="utf-8")
+    ns, var_prefix, label_to_lid = scan_owl(owl_content)
+    print(f"    Namespace  : {ns}")
+    print(f"    Var prefix : {var_prefix}")
+    print(f"    Crosswalk  : {len(label_to_lid):,} OWL classes indexed "
+          f"by snake(label)")
+
+    # 2. Run all-by-all
+    print(f"\n[2] Running all-by-all: "
+          f"'{args.phenx_collection}' vs '{args.source}' …")
+    rows = run_all_by_all(
+        args.chroma, args.phenx_collection, args.source, args.limit)
+
+    # 3. Load PhenX schema
+    print(f"\n[3] Loading {args.phenx} …")
+    collections, subcols, domains, proto_info, slot_to_proto = \
+        load_and_parse_phenx(args.phenx)
+
+    # 4. Build match_results
+    print(f"\n[4] Building match_results …")
+    print(f"    inBundleExact : similarity >= {EXACT_THRESHOLD}")
+    print(f"    inBundleClose : similarity >= {CLOSE_THRESHOLD} "
+          f"and < {EXACT_THRESHOLD}")
+    match_results = build_match_results(
+        rows, label_to_lid, slot_to_proto, proto_info)
+
+    # 5. Inject restrictions into existing OWL classes
+    print(f"\n[5] Injecting owl:equivalentClass restrictions …")
+    out, blank_nodes = inject_restrictions(
+        owl_content, match_results, proto_info, var_prefix, ns)
+
+    # 6. Append hierarchy + properties (skip if already present)
+    already_props = f"{ns}inBundleExact" in owl_content
+    already_hier  = f"{ns}bundle_phenx"  in owl_content
+    if already_props:
+        print(f"    [SKIP] Properties already present (incremental run)")
+    if already_hier:
+        print(f"    [SKIP] PhenX hierarchy already present (incremental run)")
+
+    prop_owl = "" if already_props else build_property_owl(ns)
+    hier_owl = "" if already_hier  else build_hierarchy_owl(
+        collections, subcols, domains, proto_info, ns)
+
+    if f'xmlns:{args.ns_prefix}=' not in out:
+        out = out.replace('<rdf:RDF',
+                          f'<rdf:RDF\n   xmlns:{args.ns_prefix}="{ns}"', 1)
+
+    out = out.replace(
+        "</rdf:RDF>",
+        blank_nodes + prop_owl + hier_owl + "\n</rdf:RDF>",
+    )
+
+    # 7. Write
+    print(f"\n[6] Writing → {args.out}")
+    Path(args.out).write_text(out, encoding="utf-8")
+    size_mb = Path(args.out).stat().st_size / 1024 / 1024
+
+    n_exact = sum(len(v["exact"]) for v in match_results.values())
+    n_close = sum(len(v["close"]) for v in match_results.values())
+    print(f"""
+── Summary ──────────────────────────────────────────────────────────────
+  Input OWL      : {args.owl}
+  PhenX schema   : {args.phenx}
+  ChromaDB       : {args.chroma}
+  Reference      : {args.phenx_collection}
+  Source         : {args.source}
+  OWL crosswalk  : {len(label_to_lid):,} classes
+  Matched classes: {len(match_results):,}
+  inBundleExact  : {n_exact:,} protocol links  (>= {EXACT_THRESHOLD})
+  inBundleClose  : {n_close:,} protocol links  (>= {CLOSE_THRESHOLD}, < {EXACT_THRESHOLD})
+  Output         : {args.out}  ({size_mb:.1f} MB)
+─────────────────────────────────────────────────────────────────────────""")
+
+
+if __name__ == "__main__":
+    main()

--- a/cde2vec/README.md
+++ b/cde2vec/README.md
@@ -28,13 +28,15 @@ Use the Makefile to index any supported ontology or schema:
 
 ### 🔹 Embed CDE Schemas
 
-| Make Target              | Description                                                      |
-|--------------------------|------------------------------------------------------------------|
-| `make embed-nih-cde`     | Embed NIH/NLM CDE schema from `linkml/nih_nlm_schema.yaml`      |
-| `make embed-phenx-cde`   | Embed PhenX CDE schema from `linkml/phenx_schema.yaml`          |
-| `make embed-radx-up-cde` | Embed RADx-UP CDE schema from `linkml/radx_up_schema.yaml`      |
-| `make embed-heal-cde`    | Embed HEAL CDE schema from `linkml/heal_schema.yaml`            |
-| `make embed-connects-cde`| Embed CONNECTS CDE schema from `linkml/connects_schema.yaml`    |
+| Make Target               | Description                                                         |
+|---------------------------|---------------------------------------------------------------------|
+| `make embed-nih-cde`      | Embed NIH/NLM CDE schema from `linkml/nih_nlm_schema.yaml`          |
+| `make embed-phenx-cde`    | Embed PhenX CDE schema from `linkml/phenx_schema.yaml`              |
+| `make embed-radx-up-cde`  | Embed RADx-UP CDE schema from `linkml/radx_up_schema.yaml`          |
+| `make embed-heal-cde`     | Embed HEAL CDE schema from `linkml/heal_schema.yaml`                |
+| `make embed-connects-cde` | Embed CONNECTS CDE schema from `linkml/connects_schema.yaml`        |
+| `make embed-phenx-bundle` | Embed Phenx protocols schema from `linkml/phenx_bundle_schema.yaml` |
+| `make embed-omop-cdm`     | Embed OMOP CDM schema from `linkml/omop_cdm_schema.yaml`            |
 
 ## 🔹 Embed NIDDK Study Variables (NIDDK Central Repository)
 

--- a/utils/omop_scraper.py
+++ b/utils/omop_scraper.py
@@ -1,0 +1,483 @@
+#!/usr/bin/env python3
+"""
+omop_scraper.py  –  OMOP CDM full-hierarchy builder
+====================================================
+Produces:  TableGroup → Table → Column
+           (parallel to PhenX: Collection → SubCollection → Protocol → Variable)
+
+Data source: two canonical CSV files from the OHDSI CommonDataModel GitHub repo
+  OMOP_CDMv{version}_Table_Level.csv  — one row per table
+  OMOP_CDMv{version}_Field_Level.csv  — one row per column
+
+Table groups are discovered at runtime by fetching the cdm{version}.Rmd source
+from GitHub, which contains the authoritative group-boundary trigger tables
+(the same logic used to render the official OHDSI docs page).
+If that fetch fails, the CSV `schema` field is used as a coarse fallback.
+
+QUICK START
+-----------
+    pip install requests openpyxl
+    python omop_scraper.py                        # CDM v5.4 → omop_5.4.xlsx
+    python omop_scraper.py --version 5.4          # explicit → omop_5.4.xlsx
+    python omop_scraper.py --version 5.4 --out data/omop_5.4.xlsx
+
+OUTPUT
+------
+    omop_{version}.xlsx  – README | Tables | Columns | Reference
+    omop_{version}.csv   – flat column rows (same data as Columns sheet)
+"""
+
+import argparse
+import csv
+import io
+import re
+import sys
+import time
+from collections import defaultdict
+from pathlib import Path
+
+import requests
+from openpyxl import Workbook
+from openpyxl.styles import Alignment, Border, Font, PatternFill, Side
+from openpyxl.utils import get_column_letter
+
+# ── Config ────────────────────────────────────────────────────────────────────
+GITHUB_RAW      = "https://raw.githubusercontent.com/OHDSI/CommonDataModel"
+DOCS_BASE       = "https://ohdsi.github.io/CommonDataModel"
+BROWSER_UA      = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36"
+)
+DEFAULT_VERSION = "5.4"
+
+
+# ── HTTP ──────────────────────────────────────────────────────────────────────
+
+def _session():
+    s = requests.Session()
+    s.headers.update({"User-Agent": BROWSER_UA})
+    return s
+
+
+def _get_text(session, url, retries=3, delay=1.0):
+    for attempt in range(1, retries + 1):
+        time.sleep(delay)
+        try:
+            r = session.get(url, timeout=30)
+            if r.status_code == 429:
+                wait = int(r.headers.get("Retry-After", 60))
+                print(f"\n  [rate-limit] sleeping {wait}s", file=sys.stderr)
+                time.sleep(wait)
+                continue
+            r.raise_for_status()
+            return r.text
+        except requests.RequestException as e:
+            if attempt == retries:
+                print(f"\n  [error] {url}: {e}", file=sys.stderr)
+                return None
+            time.sleep(delay * 3)
+    return None
+
+
+# ── Phase 0: fetch canonical CSVs from OHDSI GitHub ──────────────────────────
+
+def fetch_cdm_data(session, version, delay):
+    """
+    Fetch Table_Level and Field_Level CSVs from the OHDSI CommonDataModel repo.
+    Tag format: v{version}.0  (e.g. v5.4.0).
+    Returns (table_rows, field_rows) — lists of dicts, in CSV row order.
+    """
+    tag      = f"v{version}.0"
+    base_url = f"{GITHUB_RAW}/{tag}/inst/csv"
+
+    print(f"Fetching Table_Level CSV (v{version}) …", end=" ", flush=True)
+    table_text = _get_text(session, f"{base_url}/OMOP_CDMv{version}_Table_Level.csv", delay=delay)
+    if not table_text:
+        raise RuntimeError("Could not fetch Table_Level CSV")
+    tables = list(csv.DictReader(io.StringIO(table_text)))
+    print(f"{len(tables)} tables")
+
+    print(f"Fetching Field_Level CSV (v{version}) …", end=" ", flush=True)
+    field_text = _get_text(session, f"{base_url}/OMOP_CDMv{version}_Field_Level.csv", delay=delay)
+    if not field_text:
+        raise RuntimeError("Could not fetch Field_Level CSV")
+    fields = list(csv.DictReader(io.StringIO(field_text)))
+    print(f"{len(fields)} fields")
+
+    return tables, fields
+
+
+# ── Phase 1: resolve table groups from Rmd source ────────────────────────────
+
+def fetch_group_boundaries(session, version, delay):
+    """
+    Fetch cdm{version}.Rmd from GitHub and extract the group-boundary trigger
+    tables — the same if/cat blocks used to render the official OHDSI docs.
+
+    Returns dict: trigger_table_upper → group_name
+    e.g. {'PERSON': 'Clinical_Data_Tables', 'LOCATION': 'Health_System_Data_Tables', ...}
+    """
+    tag     = f"v{version}.0"
+    ver_str = version.replace(".", "")   # "5.4" → "54"
+    rmd_url = f"{GITHUB_RAW}/{tag}/rmd/cdm{ver_str}.Rmd"
+
+    print(f"Fetching cdm{ver_str}.Rmd for group taxonomy …", end=" ", flush=True)
+    text = _get_text(session, rmd_url, delay=delay)
+    if not text:
+        print("FAILED — falling back to schema field")
+        return {}
+
+    # Pattern: if(tb == 'TABLE'){ cat("## **Group Name**\n\n") }
+    # We look for  if(tb == 'X'){  followed soon by  cat("## **Y**
+    pat = re.compile(
+        r"if\s*\(\s*tb\s*==\s*'([A-Z_]+)'\s*\)\s*\{[^}]*"
+        r'cat\s*\(\s*"##\s*\*\*([^*]+)\*\*',
+        re.DOTALL
+    )
+    boundaries = {}
+    for m in pat.finditer(text):
+        table      = m.group(1).strip().upper()
+        group_raw  = m.group(2).strip()
+        # Normalise: "Clinical Data Tables" → "Clinical_Data_Tables"
+        group_name = re.sub(r'\s+', '_', group_raw)
+        boundaries[table] = group_name
+
+    print(f"{len(boundaries)} boundaries found: {list(boundaries.values())}")
+    return boundaries
+
+
+def resolve_groups(tables, session, version, delay):
+    """
+    Assign each table a group name.
+
+    Priority:
+      1. Rmd group-boundary scan (authoritative, matches OHDSI docs page h2 headings)
+      2. CSV `schema` field as coarse fallback (CDM/VOCAB/RESULTS → *_Tables)
+
+    Tables whose schema=RESULTS (COHORT, COHORT_DEFINITION) are not in the Rmd
+    loop so they get schema-field fallback → Results_Tables.
+
+    Returns dict: table_name_upper → group_name
+    """
+    boundaries = fetch_group_boundaries(session, version, delay)
+
+    # Walk tables in CSV order, carrying current group forward from each boundary
+    current_group = None
+    t2g = {}
+    for row in tables:
+        tname  = row["cdmTableName"].strip().upper()
+        schema = row.get("schema", "CDM").strip().upper()
+
+        if tname in boundaries:
+            current_group = boundaries[tname]
+
+        if current_group:
+            t2g[tname] = current_group
+        else:
+            # Fallback: schema field
+            t2g[tname] = f"{schema.capitalize()}_Tables"
+
+        # Schema=RESULTS tables are not in the Rmd loop — override
+        if schema == "RESULTS":
+            t2g[tname] = "Results_Tables"
+
+    return t2g
+
+
+# ── Phase 2: build structured rows ───────────────────────────────────────────
+
+def build_rows(tables, fields, t2g, version):
+    """
+    Build one row per table (rows_t) and one row per column (rows_c).
+    All values come from the CSV — nothing is hardcoded.
+
+    Column ID format:  OMOPColumn_{TABLE}__{field}   (parallel to PX variable IDs)
+    """
+    t_meta   = {r["cdmTableName"].strip().upper(): r for r in tables}
+    doc_slug = f"cdm{version.replace('.', '')}"   # "5.4" → "cdm54"
+
+    rows_t = []
+    rows_c = []
+
+    for tname, trow in t_meta.items():
+        group    = t2g.get(tname, "CDM_Tables")
+        schema   = trow.get("schema", "").strip()
+        t_desc   = trow.get("tableDescription", "").strip()
+        u_guide  = trow.get("userGuidance", "").strip()
+        etl_conv = trow.get("etlConventions", "").strip()
+        is_req   = trow.get("isRequired", "").strip()
+        tbl_url  = f"{DOCS_BASE}/{doc_slug}.html#{tname.lower()}"
+
+        tbl_cols = [f for f in fields if f["cdmTableName"].strip().upper() == tname]
+
+        rows_t.append({
+            "table_group":       group,
+            "table_name":        tname,
+            "schema":            schema,
+            "is_required":       is_req,
+            "table_description": t_desc[:600],
+            "user_guidance":     u_guide[:400],
+            "etl_conventions":   etl_conv[:400],
+            "n_columns":         len(tbl_cols),
+            "table_url":         tbl_url,
+            "cdm_version":       version,
+        })
+
+        for col in tbl_cols:
+            col_name = col.get("cdmFieldName",    "").strip()
+            col_req  = col.get("isRequired",      "").strip()
+            col_type = col.get("cdmDatatype",     "").strip()
+            col_guid = col.get("userGuidance",    "").strip()
+            col_etl  = col.get("etlConventions",  "").strip()
+            is_pk    = col.get("isPrimaryKey",    "").strip()
+            is_fk    = col.get("isForeignKey",    "").strip()
+            fk_table = col.get("fkTableName",     "").strip()
+            fk_field = col.get("fkFieldName",     "").strip()
+            fk_dom   = col.get("fkDomain",        "").strip()
+            fk_class = col.get("fkClass",         "").strip()
+
+            # Unique column ID: OMOPColumn_{TABLE}__{field}
+            col_id = f"OMOPColumn_{tname}__{col_name}"
+
+            rows_c.append({
+                "column_id":          col_id,
+                "column_name":        col_name,
+                "column_description": col_guid[:600] if col_guid else col_name,
+                "etl_conventions":    col_etl[:400],
+                "datatype":           col_type,
+                "is_required":        col_req,
+                "is_primary_key":     is_pk,
+                "is_foreign_key":     is_fk,
+                "fk_table":           fk_table,
+                "fk_field":           fk_field,
+                "fk_domain":          fk_dom,
+                "fk_class":           fk_class,
+                "table_name":         tname,
+                "table_group":        group,
+                "table_description":  t_desc[:300],
+                "table_url":          tbl_url,
+                "schema":             schema,
+                "cdm_version":        version,
+            })
+
+    return rows_t, rows_c
+
+
+# ── Excel builder ─────────────────────────────────────────────────────────────
+
+HDR_FILL = PatternFill("solid", start_color="1F4E79")
+ALT_FILL = PatternFill("solid", start_color="D6E4F0")
+WHITE    = PatternFill("solid", start_color="FFFFFF")
+HDR_FONT = Font(name="Arial", bold=True, color="FFFFFF", size=11)
+BDY_FONT = Font(name="Arial", size=9)
+BLD_FONT = Font(name="Arial", bold=True, size=9)
+LNK_FONT = Font(name="Arial", size=9, color="1155CC", underline="single")
+_thin    = Side(style="thin", color="BFBFBF")
+BORDER   = Border(left=_thin, right=_thin, top=_thin, bottom=_thin)
+WRAP     = Alignment(vertical="top", wrap_text=True)
+
+def _h(cell, text):
+    cell.value     = text
+    cell.font      = HDR_FONT
+    cell.fill      = HDR_FILL
+    cell.alignment = Alignment(horizontal="center", vertical="center", wrap_text=True)
+    cell.border    = BORDER
+
+def _b(cell, val, alt=False, bold=False, link=False):
+    cell.value     = val
+    cell.font      = LNK_FONT if link else (BLD_FONT if bold else BDY_FONT)
+    cell.fill      = ALT_FILL if alt else WHITE
+    cell.alignment = WRAP
+    cell.border    = BORDER
+
+def _w(ws, col, w):
+    ws.column_dimensions[get_column_letter(col)].width = w
+
+def _title(ws, text, ncols):
+    ws.merge_cells(f"A1:{get_column_letter(ncols)}1")
+    c           = ws.cell(1, 1)
+    c.value     = text
+    c.font      = Font(name="Arial", bold=True, size=12, color="FFFFFF")
+    c.fill      = HDR_FILL
+    c.alignment = Alignment(horizontal="center", vertical="center")
+    ws.row_dimensions[1].height = 26
+
+
+def build_excel(rows_t, rows_c, version, out_path):
+    wb     = Workbook()
+    tag    = f"v{version}.0"
+    n_grps = len(set(r["table_group"] for r in rows_t))
+
+    # ── README ────────────────────────────────────────────────────────────────
+    ws0       = wb.active
+    ws0.title = "README"
+    ws0.column_dimensions["A"].width = 26
+    ws0.column_dimensions["B"].width = 90
+    meta = [
+        ("Source",          f"{DOCS_BASE}/cdm{version.replace('.','')}.html"),
+        ("CDM Version",     f"OMOP CDM v{version}"),
+        ("Generated",       time.strftime("%Y-%m-%d")),
+        ("Table Groups",    str(n_grps)),
+        ("Tables",          str(len(rows_t))),
+        ("Columns / CDEs",  str(len(rows_c))),
+        ("Hierarchy",       "TableGroup → Table → Column"),
+        ("Sheets",          "README | Tables | Columns | Reference"),
+        ("CDM R Package",   "https://github.com/OHDSI/CommonDataModel"),
+        ("Table-level CSV", f"{GITHUB_RAW}/{tag}/inst/csv/OMOP_CDMv{version}_Table_Level.csv"),
+        ("Field-level CSV", f"{GITHUB_RAW}/{tag}/inst/csv/OMOP_CDMv{version}_Field_Level.csv"),
+        ("Group taxonomy",  f"{GITHUB_RAW}/{tag}/rmd/cdm{version.replace('.','')}.Rmd"),
+        ("License",         "Apache 2.0 – OHDSI CommonDataModel"),
+    ]
+    for r, (k, v) in enumerate(meta, 1):
+        ws0.cell(r, 1).value = k
+        ws0.cell(r, 1).font  = Font(name="Arial", bold=True, size=10)
+        ws0.cell(r, 2).value = v
+        ws0.cell(r, 2).font  = Font(name="Arial", size=10)
+
+    # ── Tables ────────────────────────────────────────────────────────────────
+    ws1 = wb.create_sheet("Tables")
+    ws1.freeze_panes = "A3"
+    T_HDRS = [
+        "Table Group", "Table Name", "Schema", "Is Required",
+        "Table Description", "User Guidance", "ETL Conventions",
+        "# Columns", "Table URL", "CDM Version",
+    ]
+    _title(ws1, f"OMOP CDM v{version} – Tables ({len(rows_t)})  |  {DOCS_BASE}", len(T_HDRS))
+    ws1.row_dimensions[2].height = 18
+    for c, h in enumerate(T_HDRS, 1):
+        _h(ws1.cell(2, c), h)
+    for i, w in enumerate([32, 28, 14, 12, 65, 55, 55, 10, 60, 12], 1):
+        _w(ws1, i, w)
+    for i, t in enumerate(rows_t):
+        r = i + 3
+        alt = i % 2 == 1
+        vals = [
+            t["table_group"],       t["table_name"],
+            t["schema"],            t["is_required"],
+            t["table_description"], t["user_guidance"],
+            t["etl_conventions"],   str(t["n_columns"]),
+            t["table_url"],         t["cdm_version"],
+        ]
+        for c, v in enumerate(vals, 1):
+            _b(ws1.cell(r, c), v, alt, bold=(c == 2), link=(c == 9))
+        ws1.row_dimensions[r].height = 36
+
+    # ── Columns / CDEs ────────────────────────────────────────────────────────
+    ws2 = wb.create_sheet("Columns (CDEs)")
+    ws2.freeze_panes = "A3"
+    C_HDRS = [
+        "Column ID (CDE ID)", "Column Name", "Column Description",
+        "ETL Conventions", "Datatype", "Is Required",
+        "Is Primary Key", "Is Foreign Key",
+        "FK Table", "FK Field", "FK Domain", "FK Class",
+        "Table Name", "Table Group", "Table Description", "Table URL",
+        "Schema", "CDM Version",
+    ]
+    _title(ws2, f"OMOP CDM v{version} – Columns / CDEs ({len(rows_c)})  |  {DOCS_BASE}", len(C_HDRS))
+    ws2.row_dimensions[2].height = 18
+    for c, h in enumerate(C_HDRS, 1):
+        _h(ws2.cell(2, c), h)
+    for i, w in enumerate(
+        [40, 32, 65, 55, 12, 12, 14, 14, 24, 20, 18, 16, 28, 32, 55, 60, 12, 12], 1
+    ):
+        _w(ws2, i, w)
+    for i, col in enumerate(rows_c):
+        r = i + 3
+        alt = i % 2 == 1
+        vals = [
+            col["column_id"],          col["column_name"],
+            col["column_description"], col["etl_conventions"],
+            col["datatype"],           col["is_required"],
+            col["is_primary_key"],     col["is_foreign_key"],
+            col["fk_table"],           col["fk_field"],
+            col["fk_domain"],          col["fk_class"],
+            col["table_name"],         col["table_group"],
+            col["table_description"],  col["table_url"],
+            col["schema"],             col["cdm_version"],
+        ]
+        for c, v in enumerate(vals, 1):
+            _b(ws2.cell(r, c), v, alt, bold=(c == 1), link=(c == 16))
+        ws2.row_dimensions[r].height = 30
+
+    # ── Reference ─────────────────────────────────────────────────────────────
+    ws3 = wb.create_sheet("Reference")
+    ws3.freeze_panes = "A2"
+    for c, h in enumerate(
+        ["Table Group", "Schema", "Table Name", "Is Required", "# Columns", "Table URL"], 1
+    ):
+        _h(ws3.cell(1, c), h)
+    ws3.row_dimensions[1].height = 18
+    for i, w in enumerate([32, 12, 28, 12, 10, 65], 1):
+        _w(ws3, i, w)
+    for i, t in enumerate(rows_t):
+        r = i + 2
+        alt = i % 2 == 1
+        _b(ws3.cell(r, 1), t["table_group"],   alt, bold=True)
+        _b(ws3.cell(r, 2), t["schema"],         alt)
+        _b(ws3.cell(r, 3), t["table_name"],     alt, bold=True)
+        _b(ws3.cell(r, 4), t["is_required"],    alt)
+        _b(ws3.cell(r, 5), str(t["n_columns"]), alt)
+        _b(ws3.cell(r, 6), t["table_url"],      alt, link=True)
+        ws3.row_dimensions[r].height = 20
+
+    wb.save(out_path)
+    print(f"Saved Excel → {out_path}")
+
+
+def write_csv(rows_c, path):
+    if not rows_c:
+        return
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=list(rows_c[0].keys()))
+        w.writeheader()
+        w.writerows(rows_c)
+    print(f"Saved CSV   → {path}")
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Build OMOP CDM hierarchy → TableGroup → Table → Column",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    ap.add_argument("--version", default=DEFAULT_VERSION,
+                    help=f"CDM version to fetch (default: {DEFAULT_VERSION})")
+    ap.add_argument("--delay",   type=float, default=0.5,
+                    help="Seconds between HTTP requests (default 0.5)")
+    ap.add_argument("--out",     default=None,
+                    help="Output Excel path (default: omop_{version}.xlsx)")
+    args = ap.parse_args()
+
+    out_xlsx = Path(args.out) if args.out else Path(f"omop_{args.version}.xlsx")
+    out_csv  = out_xlsx.with_suffix(".csv")
+    session  = _session()
+
+    print("=" * 60)
+    print(f"OMOP CDM v{args.version} hierarchy builder")
+    print("=" * 60)
+
+    print("\nPhase 0: fetching canonical CDM CSVs from OHDSI GitHub …")
+    tables, fields = fetch_cdm_data(session, args.version, args.delay)
+
+    print("\nPhase 1: resolving table groups …")
+    t2g = resolve_groups(tables, session, args.version, args.delay)
+    by_group = defaultdict(list)
+    for t, g in t2g.items():
+        by_group[g].append(t)
+    for grp in sorted(by_group):
+        print(f"  {grp:<40}  {len(by_group[grp])} tables: {by_group[grp]}")
+
+    print("\nPhase 2: building structured rows …")
+    rows_t, rows_c = build_rows(tables, fields, t2g, args.version)
+    print(f"  → {len(rows_t)} tables, {len(rows_c)} columns")
+
+    print(f"\n{'='*60}\nWriting outputs …")
+    build_excel(rows_t, rows_c, args.version, out_xlsx)
+    write_csv(rows_c, out_csv)
+    print("Done ✓")
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/phenx_scraper.py
+++ b/utils/phenx_scraper.py
@@ -1,0 +1,727 @@
+#!/usr/bin/env python3
+"""
+phenx_scraper.py  –  PhenX Toolkit full-hierarchy scraper
+==========================================================
+Produces:  Collection → Sub-collection → Protocol → Variable (CDE)
+           Domain     → Protocol        → Variable (CDE)
+
+Zero hardcoding: collections and domains are discovered by scraping
+/collections and /domains at runtime, so new ones appear automatically.
+
+QUICK START
+-----------
+    pip install requests beautifulsoup4 openpyxl
+    python phenx_scraper.py               # all ~1010 protocols
+    python phenx_scraper.py --limit 10    # smoke-test
+    python phenx_scraper.py --resume      # continue after interrupt
+
+OUTPUT
+------
+    phenx_hierarchy.xlsx     – README | Protocols | Variables(CDEs) | Reference
+    phenx_hierarchy.csv      – flat CDE rows (same data as Variables sheet)
+    phenx_checkpoint.json    – resume checkpoint (written next to --out by
+                                default, or at --checkpoint-path if given;
+                                deleted automatically on a successful run)
+"""
+
+import argparse
+import csv
+import json
+import re
+import sys
+import time
+from pathlib import Path
+
+import requests
+from bs4 import BeautifulSoup
+from openpyxl import Workbook
+from openpyxl.styles import Alignment, Border, Font, PatternFill, Side
+from openpyxl.utils import get_column_letter
+
+# ── Config ────────────────────────────────────────────────────────────────────
+BASE            = "https://www.phenxtoolkit.org"
+BROWSER_UA      = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36"
+)
+
+# ── HTTP ──────────────────────────────────────────────────────────────────────
+
+def make_session():
+    s = requests.Session()
+    s.headers.update({
+        "User-Agent": BROWSER_UA,
+        "Accept": "text/html,application/xhtml+xml;q=0.9,*/*;q=0.8",
+        "Accept-Language": "en-US,en;q=0.9",
+    })
+    return s
+
+
+def get_soup(session, url, delay=0.8, retries=3):
+    """Fetch URL with retries; return BeautifulSoup or None."""
+    for attempt in range(1, retries + 1):
+        time.sleep(delay)
+        try:
+            r = session.get(url, timeout=30)
+            if r.status_code == 429:
+                wait = int(r.headers.get("Retry-After", 60))
+                print(f"\n  [rate-limit] sleeping {wait}s", file=sys.stderr)
+                time.sleep(wait)
+                continue
+            r.raise_for_status()
+            return BeautifulSoup(r.text, "html.parser")
+        except requests.RequestException as e:
+            if attempt == retries:
+                print(f"\n  [error] {url}: {e}", file=sys.stderr)
+                return None
+            time.sleep(delay * 3)
+    return None
+
+
+def _abs(href):
+    """Make a href absolute."""
+    if href.startswith("http"):
+        return href
+    return BASE + href
+
+
+def _id_from_url(url, pattern):
+    """Extract numeric ID from a URL using a regex pattern string."""
+    m = re.search(pattern, url)
+    return m.group(1) if m else ""
+
+
+# ── Phase 0: discover collections and domains from index pages ────────────────
+
+def scrape_collections(session, delay):
+    """
+    Scrape /collections → list of dicts:
+        {id, name, url}
+    """
+    print("Scraping /collections index …", end=" ", flush=True)
+    soup = get_soup(session, f"{BASE}/collections", delay)
+    if soup is None:
+        raise RuntimeError("Could not fetch /collections")
+
+    results, seen = [], set()
+    for a in soup.select("a[href*='/collections/view/']"):
+        href = a["href"]
+        cid  = _id_from_url(href, r"/collections/view/(\d+)")
+        name = a.get_text(strip=True)
+        if cid and name and cid not in seen:
+            seen.add(cid)
+            results.append({"id": cid, "name": name, "url": _abs(href)})
+
+    print(f"{len(results)} collections found")
+    return results
+
+
+def scrape_domains(session, delay):
+    """
+    Scrape /domains → list of dicts:
+        {id, name, url}
+    """
+    print("Scraping /domains index …", end=" ", flush=True)
+    soup = get_soup(session, f"{BASE}/domains", delay)
+    if soup is None:
+        raise RuntimeError("Could not fetch /domains")
+
+    results, seen = [], set()
+    for a in soup.select("a[href*='/domains/view/']"):
+        href = a["href"]
+        did  = _id_from_url(href, r"/domains/view/(\d+)")
+        name = a.get_text(strip=True)
+        if did and name and did not in seen:
+            seen.add(did)
+            results.append({"id": did, "name": name, "url": _abs(href)})
+
+    print(f"{len(results)} domains found")
+    return results
+
+
+# ── Phase 1: discover protocols ───────────────────────────────────────────────
+
+def _extract_proto_links(soup):
+    """Return list of (protocol_id, protocol_name) from any page."""
+    results, seen = [], set()
+    for a in soup.select("a[href*='/protocols/view/']"):
+        pid  = _id_from_url(a["href"], r"/protocols/view/(\d+)")
+        name = a.get_text(" ", strip=True)
+        if pid and name and pid not in seen and not name.startswith("http"):
+            seen.add(pid)
+            results.append((pid, name))
+    return results
+
+
+def discover_from_domains(session, domains, delay):
+    """
+    Scrape each domain page for protocol links.
+    Returns dict: protocol_id → stub dict
+    """
+    print("\nPhase 1a: protocols from domain pages …")
+    stubs = {}
+    for dom in domains:
+        print(f"  domain [{dom['id']}] {dom['name'][:45]:<45} … ", end="", flush=True)
+        soup = get_soup(session, dom["url"], delay)
+        if soup is None:
+            print("SKIP")
+            continue
+        added = 0
+        for pid, pname in _extract_proto_links(soup):
+            if pid not in stubs:
+                stubs[pid] = {
+                    "protocol_id":   pid,
+                    "protocol_name": pname,
+                    "domain_id":     dom["id"],
+                    "domain_name":   dom["name"],
+                    "domain_url":    dom["url"],
+                }
+                added += 1
+        print(f"+{added:3}  (total {len(stubs)})")
+    return stubs
+
+
+def discover_from_collections(session, collections, delay):
+    """
+    Scrape each collection page → sub-collection pages → protocol links.
+
+    Returns:
+      proto_cols: dict  protocol_id → list of col_entry dicts
+      col_stubs:  dict  protocol_id → basic stub
+    """
+    print("\nPhase 1b: protocols from collection/sub-collection pages …")
+    proto_cols = {}   # pid → [col_entry, …]
+    col_stubs  = {}   # pid → stub
+
+    for col in collections:
+        print(f"  collection [{col['id']}] {col['name'][:40]:<40} … ", end="", flush=True)
+        soup = get_soup(session, col["url"], delay)
+        if soup is None:
+            print("SKIP")
+            continue
+
+        # Discover sub-collections listed on this page
+        sub_cols, seen_sc = [], set()
+        for a in soup.select("a[href*='/sub-collections/view/']"):
+            scid = _id_from_url(a["href"], r"/sub-collections/view/(\d+)")
+            if scid and scid not in seen_sc:
+                seen_sc.add(scid)
+                sub_cols.append({
+                    "id":   scid,
+                    "name": a.get_text(strip=True),
+                    "url":  _abs(a["href"]),
+                })
+
+        print(f"{len(sub_cols)} sub-cols … ", end="", flush=True)
+        new_p = 0
+
+        for sc in sub_cols:
+            sc_soup = get_soup(session, sc["url"], delay)
+            if sc_soup is None:
+                continue
+            for pid, pname in _extract_proto_links(sc_soup):
+                entry = {
+                    "collection_id":       col["id"],
+                    "collection_name":     col["name"],
+                    "collection_url":      col["url"],
+                    "sub_collection_id":   sc["id"],
+                    "sub_collection_name": sc["name"],
+                    "sub_collection_url":  sc["url"],
+                }
+                # append (a protocol can be in multiple sub-collections)
+                proto_cols.setdefault(pid, []).append(entry)
+
+                if pid not in col_stubs:
+                    col_stubs[pid] = {
+                        "protocol_id":   pid,
+                        "protocol_name": pname,
+                        "domain_id":     "",
+                        "domain_name":   "",
+                        "domain_url":    "",
+                    }
+                    new_p += 1
+
+        print(f"+{new_p} new protocols")
+
+    return proto_cols, col_stubs
+
+
+# ── Phase 2: protocol detail + variable parsing ───────────────────────────────
+
+def parse_variables(soup):
+    """
+    Parse the Variables table on a protocol page.
+
+    HTML pattern (2 rows per variable):
+      Row A (group/name):  PX030703_Age_FirstCigarette_Adult_First_Time | "" | "" | ""
+      Row B (data):        ""  |  PX030703030000  |  description text  |  dbGaP value
+
+    Correct column mapping:
+      col 0 = Variable Name (group identifier, e.g. PX030703_…)
+      col 1 = Variable ID   (12-digit, e.g. PX030703030000)
+      col 2 = Variable Description
+      col 3 = dbGaP Mapping
+    """
+    # Locate the variable table
+    var_tbl = None
+    for tag in soup.find_all(["h5", "h6", "strong"]):
+        if tag.get_text(strip=True) in ("Variables", "## Variables"):
+            var_tbl = tag.find_next("table")
+            break
+    if var_tbl is None:
+        for tbl in soup.find_all("table"):
+            hdrs = [th.get_text(strip=True) for th in tbl.find_all("th")]
+            if "Variable Name" in hdrs or "Variable ID" in hdrs:
+                var_tbl = tbl
+                break
+    if var_tbl is None:
+        return []
+
+    variables     = []
+    current_group = ""
+
+    for tr in var_tbl.find_all("tr"):
+        tds = tr.find_all(["td", "th"])
+        if not tds:
+            continue
+        raw = [td.get_text(" ", strip=True) for td in tds]
+
+        # Skip column-header row
+        if raw[0] in ("Variable Name", "Variable ID", "Variable Description"):
+            continue
+
+        col0 = raw[0]
+        col1 = raw[1] if len(raw) > 1 else ""
+        col2 = raw[2] if len(raw) > 2 else ""
+        col3 = raw[3] if len(raw) > 3 else ""
+
+        # Row A: Variable Name (group) — PX + 6-digit protocol code + underscore suffix
+        #        col0 matches PX\d{6}_ and col1 is blank
+        is_group = (
+            bool(col0)
+            and re.match(r"^PX\d{6}_", col0)
+            and not col1.strip()
+        )
+
+        # Row B: Variable data — col0 blank, col1 is 12-digit PX ID
+        is_data = (
+            not col0.strip()
+            and bool(col1)
+            and re.match(r"^PX\d{12}$", col1)
+        )
+
+        # Edge-case: single-row format (col0=name, col1=id, col2=desc, col3=dbgap)
+        is_single = (
+            not is_group and not is_data
+            and bool(col0)
+            and bool(col1)
+            and re.match(r"^PX\d{6}_", col0)
+            and re.match(r"^PX\d{12}$", col1)
+        )
+
+        if is_group:
+            current_group = col0
+
+        elif is_data:
+            dbgap = re.sub(r"\s*Variable Mapping\s*", "mapped", col3, flags=re.I)
+            dbgap = dbgap.replace("N/A", "").strip()
+            variables.append({
+                "var_name":        current_group,   # e.g. PX030703_Age_FirstCigarette_Adult_First_Time
+                "var_id":          col1,            # e.g. PX030703030000
+                "var_description": col2,            # question text
+                "dbgap_mapping":   dbgap,
+            })
+
+        elif is_single:
+            dbgap = re.sub(r"\s*Variable Mapping\s*", "mapped", col3, flags=re.I)
+            dbgap = dbgap.replace("N/A", "").strip()
+            variables.append({
+                "var_name":        col0,
+                "var_id":          col1,
+                "var_description": col2,
+                "dbgap_mapping":   dbgap,
+            })
+
+    return variables
+
+
+def fetch_protocol(session, pid, delay, dom_by_id):
+    """Fetch a protocol detail page; return detail dict or None."""
+    url  = f"{BASE}/protocols/view/{pid}"
+    soup = get_soup(session, url, delay)
+    if soup is None:
+        return None
+
+    d = {"protocol_id": pid, "protocol_url": url}
+
+    # Name
+    h1 = soup.find("h1")
+    d["protocol_name"] = (h1.get_text(" ", strip=True)
+                           .replace("Protocol -", "").strip()) if h1 else ""
+
+    # Instrument / source
+    src = soup.find(lambda t: t.name in ("h5","h6","strong")
+                              and "Protocol Name from Source" in t.get_text())
+    d["instrument"] = (src.find_next_sibling().get_text(strip=True)[:300]
+                       if src and src.find_next_sibling() else "")
+
+    # Description
+    desc = soup.find(lambda t: t.name in ("h5","h6","strong")
+                               and t.get_text(strip=True) == "Description")
+    d["description"] = (desc.find_next_sibling().get_text(strip=True)[:600]
+                        if desc and desc.find_next_sibling() else "")
+
+    # Mode of administration
+    mode = soup.find(lambda t: t.name in ("h5","h6","strong","p")
+                               and "Mode of Administration" in t.get_text())
+    d["mode"] = (mode.find_next_sibling().get_text(strip=True)[:200]
+                 if mode and mode.find_next_sibling() else "")
+
+    # Lifestage
+    ls = soup.find(lambda t: t.name in ("h5","h6","strong")
+                             and t.get_text(strip=True) == "Lifestage")
+    d["lifestage"] = (ls.find_next_sibling().get_text(strip=True)[:100]
+                      if ls and ls.find_next_sibling() else "")
+
+    # Availability
+    av = soup.find("a", href=re.compile(r"#tabsource"))
+    d["availability"] = av.get_text(strip=True)[:120] if av else ""
+
+    # Domain — from page links, resolved against discovered domains
+    d["domain_id"] = d["domain_name"] = d["domain_url"] = ""
+    for a in soup.select("a[href*='/domains/view/']"):
+        did = _id_from_url(a["href"], r"/domains/view/(\d+)$")
+        if did and did in dom_by_id:
+            d["domain_id"]   = did
+            d["domain_name"] = dom_by_id[did]["name"]
+            d["domain_url"]  = dom_by_id[did]["url"]
+            break
+
+    # LOINC
+    d["loinc_code"] = d["loinc_name"] = ""
+    for tr in soup.select("table tr"):
+        cells = [td.get_text(strip=True) for td in tr.find_all(["td","th"])]
+        if len(cells) >= 3 and "LOINC" in cells[0]:
+            d["loinc_name"] = cells[1]
+            d["loinc_code"] = cells[2]
+            break
+
+    d["variables"] = parse_variables(soup)
+    return d
+
+
+# ── Checkpoint ────────────────────────────────────────────────────────────────
+
+def save_ckpt(done, rows_p, rows_c, checkpoint_path):
+    with open(checkpoint_path, "w") as f:
+        json.dump({"done": list(done), "protocols": rows_p, "cdes": rows_c}, f)
+
+def load_ckpt(checkpoint_path):
+    if not Path(checkpoint_path).exists():
+        return set(), [], []
+    with open(checkpoint_path) as f:
+        d = json.load(f)
+    return set(d["done"]), d["protocols"], d["cdes"]
+
+
+# ── Excel builder ─────────────────────────────────────────────────────────────
+
+HDR_FILL = PatternFill("solid", start_color="1F4E79")
+ALT_FILL = PatternFill("solid", start_color="D6E4F0")
+WHITE    = PatternFill("solid", start_color="FFFFFF")
+HDR_FONT = Font(name="Arial", bold=True, color="FFFFFF", size=11)
+BDY_FONT = Font(name="Arial", size=9)
+BLD_FONT = Font(name="Arial", bold=True, size=9)
+LNK_FONT = Font(name="Arial", size=9, color="1155CC", underline="single")
+thin     = Side(style="thin", color="BFBFBF")
+BORDER   = Border(left=thin, right=thin, top=thin, bottom=thin)
+WRAP     = Alignment(vertical="top", wrap_text=True)
+
+def _h(cell, text):
+    cell.value = text; cell.font = HDR_FONT; cell.fill = HDR_FILL
+    cell.alignment = Alignment(horizontal="center", vertical="center", wrap_text=True)
+    cell.border = BORDER
+
+def _b(cell, val, alt=False, bold=False, link=False):
+    cell.value = val
+    cell.font  = LNK_FONT if link else (BLD_FONT if bold else BDY_FONT)
+    cell.fill  = ALT_FILL if alt else WHITE
+    cell.alignment = WRAP; cell.border = BORDER
+
+def _w(ws, col, w):
+    ws.column_dimensions[get_column_letter(col)].width = w
+
+def _title(ws, text, ncols):
+    ws.merge_cells(f"A1:{get_column_letter(ncols)}1")
+    c = ws.cell(1, 1)
+    c.value = text
+    c.font  = Font(name="Arial", bold=True, size=12, color="FFFFFF")
+    c.fill  = HDR_FILL
+    c.alignment = Alignment(horizontal="center", vertical="center")
+    ws.row_dimensions[1].height = 26
+
+
+def build_excel(rows_p, rows_cde, collections, domains, out_path):
+    wb = Workbook()
+
+    # ── README ────────────────────────────────────────────────────────────────
+    ws0 = wb.active; ws0.title = "README"
+    ws0.column_dimensions["A"].width = 26
+    ws0.column_dimensions["B"].width = 90
+    meta = [
+        ("Source",            BASE),
+        ("Scraped",           time.strftime("%Y-%m-%d")),
+        ("Collections found", str(len(collections))),
+        ("Domains found",     str(len(domains))),
+        ("Protocols",         str(len(rows_p))),
+        ("CDEs / Variables",  str(len(rows_cde))),
+        ("Hierarchy",         "Collection → Sub-collection → Protocol → Variable (CDE)  "
+                              "AND  Domain → Protocol → Variable (CDE)"),
+        ("Sheets",            "README | Protocols | Variables (CDEs) | Reference"),
+        ("License",           "Creative Commons Attribution 4.0 (CC BY 4.0)"),
+        ("Attribution",       "The Web-based PhenX Toolkit currently receives funding from NIH; "
+                              "official versions at www.phenxtoolkit.org"),
+        ("Official downloads",f"{BASE}/resources/download"),
+    ]
+    for r,(k,v) in enumerate(meta, 1):
+        ws0.cell(r,1).value = k; ws0.cell(r,1).font = Font(name="Arial",bold=True,size=10)
+        ws0.cell(r,2).value = v; ws0.cell(r,2).font = Font(name="Arial",size=10)
+
+    # ── Protocols ─────────────────────────────────────────────────────────────
+    ws1 = wb.create_sheet("Protocols")
+    ws1.freeze_panes = "A3"
+    P_HDRS = [
+        "Protocol ID","Protocol Name","Instrument / Source",
+        "Description","Mode","Lifestage","Availability",
+        "Domain ID","Domain Name","Domain URL",
+        "Sub-collection ID","Sub-collection Name","Sub-collection URL",
+        "Collection ID","Collection Name","Collection URL",
+        "LOINC Code","LOINC Name","# Variables","Protocol URL",
+    ]
+    _title(ws1, f"PhenX Toolkit – Protocols ({len(rows_p)})  |  {BASE}", len(P_HDRS))
+    ws1.row_dimensions[2].height = 18
+    for c,h in enumerate(P_HDRS,1): _h(ws1.cell(2,c), h)
+    for i,w in enumerate([12,52,55,65,30,20,40,10,40,50,12,40,50,10,40,50,12,42,10,50],1):
+        _w(ws1, i, w)
+    LINK_P = {10,13,16,20}
+    for i,p in enumerate(rows_p):
+        r=i+3; alt=i%2==1
+        vals = [
+            p.get("protocol_id",""),   p.get("protocol_name",""),
+            p.get("instrument",""),    p.get("description",""),
+            p.get("mode",""),          p.get("lifestage",""),
+            p.get("availability",""),
+            p.get("domain_id",""),     p.get("domain_name",""),    p.get("domain_url",""),
+            p.get("sub_collection_id",""),  p.get("sub_collection_name",""), p.get("sub_collection_url",""),
+            p.get("collection_id",""),      p.get("collection_name",""),     p.get("collection_url",""),
+            p.get("loinc_code",""),    p.get("loinc_name",""),
+            str(len(p.get("variables",[]))),
+            p.get("protocol_url",""),
+        ]
+        for c,v in enumerate(vals,1):
+            _b(ws1.cell(r,c), v, alt, bold=(c==2), link=(c in LINK_P))
+        ws1.row_dimensions[r].height = 32
+
+    # ── Variables / CDEs ──────────────────────────────────────────────────────
+    ws2 = wb.create_sheet("Variables (CDEs)")
+    ws2.freeze_panes = "A3"
+    V_HDRS = [
+        "Variable ID (CDE ID)","Variable Name","Variable Description",
+        "dbGaP Mapping",
+        "Protocol ID","Protocol Name","Protocol URL",
+        "Domain ID","Domain Name","Domain URL",
+        "Sub-collection ID","Sub-collection Name","Sub-collection URL",
+        "Collection ID","Collection Name","Collection URL",
+        "LOINC Code","LOINC Name",
+    ]
+    _title(ws2, f"PhenX Toolkit – Variables / CDEs ({len(rows_cde)})  |  {BASE}", len(V_HDRS))
+    ws2.row_dimensions[2].height = 18
+    for c,h in enumerate(V_HDRS,1): _h(ws2.cell(2,c), h)
+    for i,w in enumerate([22,46,65,12,12,52,50,10,40,50,12,40,50,10,40,50,12,42],1):
+        _w(ws2, i, w)
+    LINK_V = {7,10,13,16}
+    for i,v in enumerate(rows_cde):
+        r=i+3; alt=i%2==1
+        vals = [
+            v["var_id"],          v["var_name"],
+            v["var_description"], v["dbgap_mapping"],
+            v["protocol_id"],     v["protocol_name"],   v["protocol_url"],
+            v["domain_id"],       v["domain_name"],     v["domain_url"],
+            v["sub_collection_id"],   v["sub_collection_name"], v["sub_collection_url"],
+            v["collection_id"],       v["collection_name"],     v["collection_url"],
+            v["loinc_code"],      v["loinc_name"],
+        ]
+        for c,val in enumerate(vals,1):
+            _b(ws2.cell(r,c), val, alt, bold=(c==1), link=(c in LINK_V))
+        ws2.row_dimensions[r].height = 28
+
+    # ── Reference (discovered collections + domains) ──────────────────────────
+    ws3 = wb.create_sheet("Reference")
+    ws3.freeze_panes = "A2"
+    for c,h in enumerate(["Type","ID","Name","URL"],1): _h(ws3.cell(1,c), h)
+    ws3.row_dimensions[1].height = 18
+    for i,w in enumerate([14,12,62,58],1): _w(ws3,i,w)
+    ref = (
+        [("Collection", c["id"], c["name"], c["url"]) for c in collections]
+        + [("Domain",     d["id"], d["name"], d["url"]) for d in domains]
+    )
+    for i,(typ,rid,name,url) in enumerate(ref):
+        r=i+2; alt=i%2==1
+        _b(ws3.cell(r,1), typ,  alt)
+        _b(ws3.cell(r,2), rid,  alt)
+        _b(ws3.cell(r,3), name, alt, bold=True)
+        _b(ws3.cell(r,4), url,  alt, link=True)
+        ws3.row_dimensions[r].height = 20
+
+    wb.save(out_path)
+    print(f"Saved Excel → {out_path}")
+
+
+def write_csv(rows_cde, path):
+    if not rows_cde:
+        return
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=list(rows_cde[0].keys()))
+        w.writeheader(); w.writerows(rows_cde)
+    print(f"Saved CSV  → {path}")
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Scrape PhenX Toolkit → Collection→Domain→Protocol→CDE hierarchy",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    ap.add_argument("--limit",            type=int,   default=0,
+                    help="Max protocols to detail-fetch (0 = all)")
+    ap.add_argument("--delay",            type=float, default=0.8,
+                    help="Seconds between requests (default 0.8)")
+    ap.add_argument("--out",              default="phenx_hierarchy.xlsx",
+                    help="Output Excel path")
+    ap.add_argument("--resume",           action="store_true",
+                    help="Resume from checkpoint file")
+    ap.add_argument("--checkpoint-every", type=int,   default=50,
+                    help="Save checkpoint every N protocols (default 50)")
+    ap.add_argument("--checkpoint-path",  default=None,
+                    help="Path to checkpoint JSON file "
+                         "(default: <out-dir>/phenx_checkpoint.json)")
+    args = ap.parse_args()
+
+    out_xlsx  = Path(args.out)
+    out_csv   = out_xlsx.with_suffix(".csv")
+    ckpt_path = (Path(args.checkpoint_path) if args.checkpoint_path
+                 else out_xlsx.parent / "phenx_checkpoint.json")
+    ckpt_path.parent.mkdir(parents=True, exist_ok=True)
+    session   = make_session()
+
+    # ── Phase 0: discover collections and domains (no hardcoding) ────────────
+    print("=" * 60)
+    print("Phase 0: discovering collections and domains …")
+    collections = scrape_collections(session, args.delay)
+    domains     = scrape_domains(session, args.delay)
+    dom_by_id   = {d["id"]: d for d in domains}
+    print(f"  → {len(collections)} collections, {len(domains)} domains\n")
+
+    # ── Load checkpoint ───────────────────────────────────────────────────────
+    done_ids, rows_p, rows_cde = set(), [], []
+    if args.resume:
+        done_ids, rows_p, rows_cde = load_ckpt(ckpt_path)
+        print(f"Resumed: {len(done_ids)} protocols done, {len(rows_cde)} CDEs loaded\n")
+
+    # ── Phase 1: discover all protocol IDs ───────────────────────────────────
+    dom_stubs              = discover_from_domains(session, domains, args.delay)
+    proto_cols, col_stubs  = discover_from_collections(session, collections, args.delay)
+
+    # Merge: domain stubs are authoritative for domain fields
+    all_stubs = dict(col_stubs)
+    for pid, stub in dom_stubs.items():
+        if pid in all_stubs:
+            all_stubs[pid].update({
+                "domain_id":   stub["domain_id"],
+                "domain_name": stub["domain_name"],
+                "domain_url":  stub["domain_url"],
+            })
+        else:
+            all_stubs[pid] = stub
+
+    stubs = [s for s in all_stubs.values() if s["protocol_id"] not in done_ids]
+    if args.limit:
+        stubs = stubs[:args.limit]
+
+    print(f"\n{'='*60}")
+    print(f"Phase 2: fetching details for {len(stubs)} protocols "
+          f"(already done: {len(done_ids)}) …\n")
+
+    for i, stub in enumerate(stubs, 1):
+        pid = stub["protocol_id"]
+        print(f"  [{i:4}/{len(stubs)}] {pid} ", end="", flush=True)
+
+        det = fetch_protocol(session, pid, args.delay, dom_by_id)
+        if det is None:
+            print("SKIP")
+            continue
+
+        # Backfill domain from stub if page didn't resolve it
+        if not det.get("domain_id") and stub.get("domain_id"):
+            det["domain_id"]   = stub["domain_id"]
+            det["domain_name"] = stub["domain_name"]
+            det["domain_url"]  = stub["domain_url"]
+
+        # Attach first collection membership to the protocol row
+        col_entries = proto_cols.get(pid, [{}])
+        best        = col_entries[0]
+        det["sub_collection_id"]   = best.get("sub_collection_id","")
+        det["sub_collection_name"] = best.get("sub_collection_name","")
+        det["sub_collection_url"]  = best.get("sub_collection_url","")
+        det["collection_id"]       = best.get("collection_id","")
+        det["collection_name"]     = best.get("collection_name","")
+        det["collection_url"]      = best.get("collection_url","")
+
+        rows_p.append(det)
+        done_ids.add(pid)
+
+        # Emit one CDE row per variable × collection membership
+        for col_entry in (col_entries if col_entries else [{}]):
+            for var in det.get("variables", []):
+                rows_cde.append({
+                    "var_id":              var["var_id"],
+                    "var_name":            var["var_name"],
+                    "var_description":     var["var_description"],
+                    "dbgap_mapping":       var["dbgap_mapping"],
+                    "protocol_id":         det["protocol_id"],
+                    "protocol_name":       det["protocol_name"],
+                    "protocol_url":        det["protocol_url"],
+                    "domain_id":           det.get("domain_id",""),
+                    "domain_name":         det.get("domain_name",""),
+                    "domain_url":          det.get("domain_url",""),
+                    "sub_collection_id":   col_entry.get("sub_collection_id",""),
+                    "sub_collection_name": col_entry.get("sub_collection_name",""),
+                    "sub_collection_url":  col_entry.get("sub_collection_url",""),
+                    "collection_id":       col_entry.get("collection_id",""),
+                    "collection_name":     col_entry.get("collection_name",""),
+                    "collection_url":      col_entry.get("collection_url",""),
+                    "loinc_code":          det.get("loinc_code",""),
+                    "loinc_name":          det.get("loinc_name",""),
+                })
+
+        n = len(det.get("variables",[]))
+        print(f"→ {det.get('protocol_name','')[:45]}  ({n} vars)")
+
+        if i % args.checkpoint_every == 0:
+            save_ckpt(done_ids, rows_p, rows_cde, ckpt_path)
+            print(f"  ✓ checkpoint  ({len(rows_p)} protocols, {len(rows_cde)} CDEs)")
+
+    # ── Write outputs ─────────────────────────────────────────────────────────
+    print(f"\n{'='*60}")
+    print(f"Total: {len(rows_p)} protocols, {len(rows_cde)} CDEs")
+    build_excel(rows_p, rows_cde, collections, domains, out_xlsx)
+    write_csv(rows_cde, out_csv)
+    if ckpt_path.exists():
+        ckpt_path.unlink()
+    print("Done ✓")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds full pipeline support for two new sources — **PhenX Bundle** (full PhenX protocol hierarchy) and **OMOP CDM** (OHDSI Common Data Model) — across LinkML conversion, ChromaDB embedding, and ontology mapping.

## What's included

**`cde2linkml`**
- `bundle_phenx2linkml.py`, `omop2linkml.py` — LinkML schemas (`phenx_bundle_schema.yaml`, `omop_cdm_schema.yaml`)
- `cli.py` — `--phenx-bundle` / `--omop` flags 

**`cde2onto`**
- `allxall_mapper_phenx.py` — injects `inBundleExact` / `inBundleClose` against the`bundle_phenx` collection via CurateGPT `all-by-all`
- `allxall_mapper_omop.py` — same pattern, injects `inCDMExact` / `inCDMClose` against the `cdm_omop` collection

**Docs**
- `cde2linkml/README.md`, `cde2vec/README.md` — new download/convert/embed commands documented
- `cde2onto/README.md` — new, scoped to the two mapper scripts 

**Scraping (`utils/`)**
- `phenx_scraper.py` — scrapes the full PhenX Toolkit hierarchy (Collection → Sub-collection → Protocol → Variable, and
  Domain → Protocol → Variable)
- `omop_scraper.py` — builds the OMOP CDM hierarchy (TableGroup → Table → Column) from OHDSI's canonical CSVs

**Makefile**
- `download-phenx-protocols`, `download-omop-cdm` targets (output to `data/bundle-phenx/`, `data/cdm-omop/`)
- `embed-phenx-bundle`, `embed-omop-cdm` targets for the `bundle_phenx` and `cdm_omop` ChromaDB collections

## Testing

- Ran `phenx_scraper.py` and `omop_scraper.py` end to end
- Ran `cde2linkml --phenx-bundle --omop` against scraped output
- Ran `embed-phenx-bundle` / `embed-omop-cdm`
- Ran `allxall_mapper_phenx.py` against `cde_phenx`: 48,291 crosswalk classes, 19,796 matched (5,011 exact / 16,622 close)

